### PR TITLE
credit lease SDK primitives: check / trackWithReservation / prewarm

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -10,11 +10,13 @@ CLAUDE.md
 LICENSE
 README.md
 WASM_VERSION
+biome.json
 build.js
 scripts/
 testapp/
 src/cache/
 src/core/fetcher/custom.ts
+src/credits/
 src/datastream/
 src/event-capture.ts
 src/events.test.ts
@@ -27,7 +29,9 @@ src/wasm/
 src/webhooks.ts
 src/wrapper.ts
 tests/cloudflare/
+tests/integration/
 tests/unit/cache/local.test.ts
+tests/unit/credits/
 tests/unit/datastream/datastream-client.test.ts
 tests/unit/datastream/merge.test.ts
 tests/unit/datastream/websocket-client.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # Real redis-server for tests/integration/redis-stores.test.ts — the only
+    # place the credit-lease Lua scripts execute as actual Lua (the unit suite
+    # runs them against a JS fake). The suite self-skips when TEST_REDIS_URL
+    # is unset, so local `yarn test` needs no Redis.
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -57,6 +72,8 @@ jobs:
 
       - name: Test
         run: yarn test
+        env:
+          TEST_REDIS_URL: redis://localhost:6379
 
   verify-package:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ class CustomLogger implements Logger {
         // Your custom error logging logic
         console.error(`[ERROR] ${message}`, ...args);
     }
-    
+
     warn(message: string, ...args: any[]): void {
         // Your custom warning logging logic
         console.warn(`[WARN] ${message}`, ...args);
     }
-    
+
     info(message: string, ...args: any[]): void {
         // Your custom info logging logic
         console.info(`[INFO] ${message}`, ...args);
     }
-    
+
     debug(message: string, ...args: any[]): void {
         // Your custom debug logging logic
         console.debug(`[DEBUG] ${message}`, ...args);
@@ -683,7 +683,7 @@ export default {
       ttl: 1000 * 60 * 60, // 1 hour cache TTL
       keyPrefix: 'schematic:', // Optional prefix for KV keys
     });
-    
+
     // Initialize Schematic with the KV cache
     const schematic = new SchematicClient({
       apiKey: env.SCHEMATIC_API_KEY,
@@ -691,10 +691,10 @@ export default {
         flagChecks: [cache],
       }
     });
-    
+
     // Your application logic...
     // ...
-    
+
     // Don't forget to close the client when done
     schematic.close();
   }
@@ -797,6 +797,111 @@ const client = new SchematicClient({
 | `replicatorHealthURL` | `string` | — | URL to poll for replicator health status |
 | `replicatorHealthCheck` | `number` | 30000 | Health check polling interval in milliseconds |
 | `cacheTTL` | `number` | 24 hours | Cache TTL in milliseconds |
+
+## Credit Leases and Reservations
+
+For features metered by credit burndown (e.g. inference tokens), the SDK can enforce credit balances locally — without a Schematic API call on every check — using a lease-and-reservation system:
+
+- A **lease** is a tranche of credits acquired transactionally from Schematic's API. It functions as a hold against the company's credit balance until it is consumed, released, or expires.
+- A **reservation** is a client-side hold carved out of the lease at check time, sized to the upper bound of the operation's usage. This protects against races and over-spend between the check and the eventual usage report.
+- When the work completes, a track call reports actual usage; the difference between reserved and actual usage is refunded to the lease.
+
+> **Requirements:** Credit leases require [DataStream](#datastream) (or [Replicator Mode](#replicator-mode)) — lease-bearing checks are evaluated locally against cached flag and company state. In a horizontally-scaled deployment, a shared Redis backend is also required so that all SDK instances gate against the same lease balance; without one, lease state is per-process.
+
+### Setup
+
+```ts
+import { createClient } from "redis";
+import { SchematicClient } from "@schematichq/schematic-typescript-node";
+
+const redisClient = createClient({ url: "redis://localhost:6379" });
+await redisClient.connect();
+
+const client = new SchematicClient({
+    apiKey: process.env.SCHEMATIC_API_KEY,
+    useDataStream: true,
+    dataStream: {
+        redisClient, // also backs lease + reservation state automatically
+    },
+    creditLeases: {
+        defaultLeaseDuration: 5 * 60 * 1000, // lease lifetime (ms)
+        defaultReservationTTL: 60 * 1000, // how long a reservation is held if not settled by a track (ms)
+        defaultLeaseSize: 10_000, // credits requested per lease
+        lowWaterMark: 0.25, // extend the lease in the background when its balance dips below this fraction
+    },
+});
+```
+
+When `dataStream.redisClient` is configured, lease and reservation state automatically lives in the same Redis, with atomic reservations driven by Lua scripts — no additional configuration needed. To point lease state at a *different* Redis, set `creditLeases.redisClient` explicitly.
+
+### Checking and tracking
+
+`check()` reserves the operation's upper-bound usage against the lease and returns a reservation handle; `trackWithReservation()` settles it with actual usage:
+
+```ts
+// Per-request: reserve up to maxTokens against the lease.
+const result = await client.check(
+    { company: { id: "your-company-id" } },
+    "inference",
+    {
+        usage: maxTokens, // upper bound for this operation
+        eventSubtype: "inference_tokens", // the metered event
+    },
+);
+if (!result.allowed) {
+    throw new Error("credit balance exceeded");
+}
+
+const inference = await runInference(/* ... */);
+
+// Report actual usage; the unused slice of the reservation is refunded to the lease.
+await client.trackWithReservation(result.reservation!, inference.tokensUsed);
+```
+
+If the caller never settles a reservation, it expires after `defaultReservationTTL` and its credits are returned to the lease. If the work outlives the reservation's TTL, `trackWithReservation` still bills the usage — the track event carries a deterministic idempotency key, so duplicate or recovery emits never double-bill. However, the local lease balance is not re-debited on that late settle (the expired reservation's hold was already swept back to the lease), so it reads high until the lease rolls over. **Set `defaultReservationTTL` above the longest expected gap between `check()` and `trackWithReservation()`** to keep the local balance accurate.
+
+### Pre-warming
+
+To avoid paying the lease-acquire round trip on a session's first check, pre-warm leases when the user is identified:
+
+```ts
+await client.identify(
+    {
+        keys: { userId: "your-user-id" },
+        company: { keys: { id: "your-company-id" } },
+    },
+    { prewarm: ["credit-type-id"] }, // credit type IDs to acquire leases for
+);
+```
+
+Or call `client.prewarm(evalCtx, creditTypeIds)` directly.
+
+### Failure behavior
+
+By default, a check that cannot be gated (API unreachable, Redis down, lease exhausted) **fails closed** (`allowed: false`). Override per check for callers where letting traffic through is preferable to a denial:
+
+```ts
+const result = await client.check(evalCtx, "inference", {
+    usage: maxTokens,
+    eventSubtype: "inference_tokens",
+    onAcquireFailure: "fail-open",
+});
+```
+
+`fail-open` does not skip evaluation: the flag's rules still run with the credit balance assumed sufficient, so plan targeting, overrides, and all non-credit conditions still apply — only the credit gate is bypassed.
+
+### Configuration options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `defaultLeaseDuration` | `number` | 5 minutes | Lease lifetime in milliseconds |
+| `defaultReservationTTL` | `number` | 60 seconds | How long an unsettled reservation is held (ms); set above your longest expected work duration |
+| `defaultLeaseSize` | `number` | 10000 | Credits requested per lease acquire/extend |
+| `lowWaterMark` | `number` | 0.25 | Extend in the background when the lease balance dips below this fraction |
+| `sweepIntervalMs` | `number` | 1000 | Sweep interval for expired reservations (ms) |
+| `redisClient` | `RedisClient` | `dataStream.redisClient` | Redis client for lease + reservation state |
+| `redisKeyPrefix` | `string` | `dataStream.redisKeyPrefix` | Key prefix for lease + reservation keys |
+| `overrides` | `object` | — | Per-credit-type overrides of the above (keyed by credit type ID) |
 
 ## Testing
 

--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
         "ignoreUnknown": true,
         "includes": [
             "**",
+            "!!src/wasm",
             "!!dist",
             "!!**/dist",
             "!!lib",

--- a/build.js
+++ b/build.js
@@ -97,7 +97,7 @@ function inlineWasmBinary() {
   // Match the wasm-bindgen-emitted block that reads the binary off disk.
   // Captures any whitespace/comments wasm-bindgen emits between the two
   // statements so future loader updates don't silently bypass this step.
-  const loaderPattern = /const wasmPath = `\$\{__dirname\}\/rulesengine_bg\.wasm`;\s*\nconst wasmBytes = require\('fs'\)\.readFileSync\(wasmPath\);/;
+  const loaderPattern = /const wasmPath = `\$\{__dirname\}\/rulesengine_bg\.wasm`;\s*\nconst wasmBytes = require\((['\"])fs\1\)\.readFileSync\(wasmPath\);/;
   if (!loaderPattern.test(loaderSource)) {
     throw new Error(
       'WASM inlining failed: expected `const wasmPath = `${__dirname}/...`; const wasmBytes = require(\'fs\').readFileSync(wasmPath);` in ' +

--- a/package.json
+++ b/package.json
@@ -24,29 +24,30 @@
         "test:cloudflare": "node scripts/test-cloudflare.mjs"
     },
     "dependencies": {
+        "@types/ws": "^8.18.1",
         "form-data": "^4.0.4",
         "formdata-node": "^6.0.3",
         "node-fetch": "^2.7.0",
         "readable-stream": "^4.7.0",
-        "ws": "^8.18.1",
-        "@types/ws": "^8.18.1"
+        "ws": "^8.18.1"
     },
     "devDependencies": {
-        "@types/node-fetch": "^2.6.12",
-        "@types/readable-stream": "^4.0.23",
-        "webpack": "^5.105.4",
-        "ts-loader": "^9.5.4",
-        "jest": "^29.7.0",
+        "@biomejs/biome": "2.4.10",
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
-        "ts-jest": "^29.3.4",
-        "jest-environment-jsdom": "^29.7.0",
-        "msw": "2.11.2",
         "@types/node": "^20.0.0",
-        "typescript": "~5.9.3",
-        "@biomejs/biome": "2.4.10",
+        "@types/node-fetch": "^2.6.12",
+        "@types/readable-stream": "^4.0.23",
         "esbuild": "^0.25.9",
-        "miniflare": "^4.20260421.0"
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "miniflare": "^4.20260421.0",
+        "msw": "2.11.2",
+        "redis": "^4.7.0",
+        "ts-jest": "^29.3.4",
+        "ts-loader": "^9.5.4",
+        "typescript": "~5.9.3",
+        "webpack": "^5.105.4"
     },
     "browser": {
         "fs": false,

--- a/src/cache/local.ts
+++ b/src/cache/local.ts
@@ -72,6 +72,14 @@ class LocalCache<T> implements CacheProvider<T> {
         // Set timeout after item is created to avoid circular reference
         // Cap at MAX_TIMEOUT_MS to avoid 32-bit overflow; expiration field handles the real TTL
         newItem.timeoutId = setTimeout(() => this.evictItem(key, newItem), Math.min(ttl, MAX_TIMEOUT_MS));
+        // Unref so a pending eviction (up to ~24.8 days for the datastream flag
+        // cache) doesn't hold the Node event loop open after the caller is done
+        // — without this, a process that cached anything can't exit gracefully.
+        // Guarded: non-Node runtimes (browser, Cloudflare Workers) return a
+        // number with no unref.
+        if (typeof newItem.timeoutId === "object" && typeof newItem.timeoutId.unref === "function") {
+            newItem.timeoutId.unref();
+        }
         this.cache.set(key, newItem);
     }
 

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -1,22 +1,51 @@
 import { CacheProvider, CacheOptions } from "./types";
 
 /**
- * Minimal interface describing the redis client methods used by RedisCacheProvider.
- * Compatible with the 'redis' package's RedisClientType.
+ * Minimal interface describing the redis client methods used by the SDK.
+ * Compatible with the 'redis' package's RedisClientType (node-redis v4).
+ *
+ * Includes hash + sorted-set + eval surface used by the credit-lease and
+ * reservation stores to coordinate state across multiple SDK pods.
  */
 export interface RedisClient {
-  get(key: string): Promise<string | null>;
-  set(key: string, value: string): Promise<unknown>;
-  setEx(key: string, seconds: number, value: string): Promise<unknown>;
-  del(key: string | string[]): Promise<unknown>;
-  scanIterator(options: { MATCH: string; COUNT: number }): AsyncIterable<string>;
+    get(key: string): Promise<string | null>;
+    set(key: string, value: string): Promise<unknown>;
+    setEx(key: string, seconds: number, value: string): Promise<unknown>;
+    del(key: string | string[]): Promise<unknown>;
+    scanIterator(options: { MATCH: string; COUNT: number }): AsyncIterable<string>;
+    // Hash ops — used to store lease + reservation state as a single field-set
+    // so partial updates (e.g. atomic decrement on localRemainingCredits) don't
+    // step on neighboring fields.
+    hSet(key: string, field: string | Record<string, string | number>, value?: string | number): Promise<unknown>;
+    hGet(key: string, field: string): Promise<string | null | undefined>;
+    hGetAll(key: string): Promise<Record<string, string>>;
+    hDel(key: string, field: string | string[]): Promise<unknown>;
+    // Sorted-set ops — used to index reservations by expiry timestamp so the
+    // sweeper can pop expired entries in O(log n).
+    zAdd(key: string, members: { score: number; value: string } | { score: number; value: string }[]): Promise<unknown>;
+    zRangeByScore(
+        key: string,
+        min: number | string,
+        max: number | string,
+        options?: { LIMIT: { offset: number; count: number } },
+    ): Promise<string[]>;
+    zRem(key: string, member: string | string[]): Promise<unknown>;
+    zCard(key: string): Promise<number>;
+    // Lua scripts — used for the single-key atomic primitives (check-and-decrement
+    // on lease balance, claim-and-delete on a reservation). Kept single-key so
+    // they're safe under Redis Cluster (a multi-key EVAL whose keys span slots
+    // raises CROSSSLOT).
+    eval(script: string, options: { keys: string[]; arguments: string[] }): Promise<unknown>;
+    // Expiry on a millisecond-precision absolute timestamp — used to auto-clean
+    // lease + reservation rows shortly after their declared expiry.
+    pExpireAt(key: string, timestamp: number): Promise<unknown>;
 }
 
 export interface RedisOptions extends CacheOptions {
-  /** Pre-created, connected redis client */
-  client: RedisClient;
-  /** Redis key prefix for all cache keys (default: 'schematic:') */
-  keyPrefix?: string;
+    /** Pre-created, connected redis client */
+    client: RedisClient;
+    /** Redis key prefix for all cache keys (default: 'schematic:') */
+    keyPrefix?: string;
 }
 
 /**
@@ -24,73 +53,71 @@ export interface RedisOptions extends CacheOptions {
  * Accepts a pre-created redis client (e.g. from the 'redis' package)
  */
 export class RedisCacheProvider<T> implements CacheProvider<T> {
-  private client: RedisClient;
-  private defaultTTL: number;
-  private keyPrefix: string;
+    private client: RedisClient;
+    private defaultTTL: number;
+    private keyPrefix: string;
 
-  constructor(options: RedisOptions) {
-    this.client = options.client;
-    this.defaultTTL = Math.floor((options.ttl || 5000) / 1000); // Convert to seconds for Redis
-    this.keyPrefix = options.keyPrefix || 'schematic:';
-  }
-
-  private getFullKey(key: string): string {
-    return this.keyPrefix + key;
-  }
-
-  async get(key: string): Promise<T | null> {
-    const fullKey = this.getFullKey(key);
-    const value = await this.client.get(fullKey);
-
-    if (value === null) {
-      return null;
+    constructor(options: RedisOptions) {
+        this.client = options.client;
+        this.defaultTTL = Math.floor((options.ttl || 5000) / 1000); // Convert to seconds for Redis
+        this.keyPrefix = options.keyPrefix || "schematic:";
     }
 
-    return JSON.parse(value) as T;
-  }
-
-  async set(key: string, value: T, ttl?: number): Promise<void> {
-    const fullKey = this.getFullKey(key);
-    const serializedValue = JSON.stringify(value);
-    const actualTTL = ttl ? Math.floor(ttl / 1000) : this.defaultTTL;
-
-    if (actualTTL > 0) {
-      await this.client.setEx(fullKey, actualTTL, serializedValue);
-    } else {
-      await this.client.set(fullKey, serializedValue);
+    private getFullKey(key: string): string {
+        return this.keyPrefix + key;
     }
-  }
 
-  async delete(key: string): Promise<void> {
-    const fullKey = this.getFullKey(key);
-    await this.client.del(fullKey);
-  }
+    async get(key: string): Promise<T | null> {
+        const fullKey = this.getFullKey(key);
+        const value = await this.client.get(fullKey);
 
-  async deleteMissing(keysToKeep: string[], options?: { scanPattern?: string }): Promise<void> {
-    // Get all keys with our prefix using SCAN (non-blocking)
-    // Allow more specific pattern to reduce keys scanned (e.g., 'flag:*' to only scan flag keys)
-    const pattern = options?.scanPattern
-      ? this.keyPrefix + options.scanPattern
-      : this.keyPrefix + '*';
-    const fullKeysToKeep = new Set(keysToKeep.map(k => this.getFullKey(k)));
-    const keysToDelete: string[] = [];
-    const batchSize = 1000;
-
-    for await (const key of this.client.scanIterator({ MATCH: pattern, COUNT: 1000 })) {
-      if (!fullKeysToKeep.has(key)) {
-        keysToDelete.push(key);
-
-        // Delete in batches to avoid memory buildup with millions of keys
-        if (keysToDelete.length >= batchSize) {
-          await this.client.del(keysToDelete);
-          keysToDelete.length = 0; // Clear array
+        if (value === null) {
+            return null;
         }
-      }
+
+        return JSON.parse(value) as T;
     }
 
-    // Delete remaining keys
-    if (keysToDelete.length > 0) {
-      await this.client.del(keysToDelete);
+    async set(key: string, value: T, ttl?: number): Promise<void> {
+        const fullKey = this.getFullKey(key);
+        const serializedValue = JSON.stringify(value);
+        const actualTTL = ttl ? Math.floor(ttl / 1000) : this.defaultTTL;
+
+        if (actualTTL > 0) {
+            await this.client.setEx(fullKey, actualTTL, serializedValue);
+        } else {
+            await this.client.set(fullKey, serializedValue);
+        }
     }
-  }
+
+    async delete(key: string): Promise<void> {
+        const fullKey = this.getFullKey(key);
+        await this.client.del(fullKey);
+    }
+
+    async deleteMissing(keysToKeep: string[], options?: { scanPattern?: string }): Promise<void> {
+        // Get all keys with our prefix using SCAN (non-blocking)
+        // Allow more specific pattern to reduce keys scanned (e.g., 'flag:*' to only scan flag keys)
+        const pattern = options?.scanPattern ? this.keyPrefix + options.scanPattern : this.keyPrefix + "*";
+        const fullKeysToKeep = new Set(keysToKeep.map((k) => this.getFullKey(k)));
+        const keysToDelete: string[] = [];
+        const batchSize = 1000;
+
+        for await (const key of this.client.scanIterator({ MATCH: pattern, COUNT: 1000 })) {
+            if (!fullKeysToKeep.has(key)) {
+                keysToDelete.push(key);
+
+                // Delete in batches to avoid memory buildup with millions of keys
+                if (keysToDelete.length >= batchSize) {
+                    await this.client.del(keysToDelete);
+                    keysToDelete.length = 0; // Clear array
+                }
+            }
+        }
+
+        // Delete remaining keys
+        if (keysToDelete.length > 0) {
+            await this.client.del(keysToDelete);
+        }
+    }
 }

--- a/src/credits/check.ts
+++ b/src/credits/check.ts
@@ -1,0 +1,652 @@
+import { randomUUID } from "crypto";
+
+import type * as api from "../api";
+import type { CreditsClient } from "../api/resources/credits/client/Client";
+import type { DataStreamClient } from "../datastream";
+import type { Logger } from "../logger";
+import type { WasmFeatureEntitlement } from "../rules-engine";
+import type { CheckFlagOptions } from "../wrapper";
+
+import { CreditLeaseManager } from "./lease-manager";
+import type { ILeaseStore } from "./lease-store";
+import type { IReservationStore } from "./reservation-store";
+import type { CheckOptions, CheckResult, OnAcquireFailure, Reservation, ResolvedLeaseConfig } from "./types";
+
+/** Internal helper bundling everything needed to satisfy a lease-bearing check. */
+export interface CreditCheckDeps {
+    leaseStore: ILeaseStore;
+    reservations: IReservationStore;
+    manager: CreditLeaseManager;
+    datastream: DataStreamClient | undefined;
+    logger: Logger;
+    /**
+     * Report a `flag_check` event for a check the lease path resolved itself.
+     * Mirrors the plain `checkFlag` paths (which enqueue one per check) so
+     * lease-gated checks stay visible to flag-check analytics and company
+     * last-seen. Fallback exits don't call this — the plain check they
+     * delegate to enqueues its own.
+     */
+    enqueueFlagCheckEvent: (body: api.EventBodyFlagCheck) => void;
+}
+
+/** Enqueue the flag_check event for a lease-path resolution and pass the result through. */
+function emitFlagCheck(
+    deps: CreditCheckDeps,
+    evalCtx: api.CheckFlagRequestBody,
+    result: CheckResult,
+    ids?: { companyId?: string; userId?: string; ruleId?: string },
+): CheckResult {
+    deps.enqueueFlagCheckEvent({
+        flagKey: result.flagKey,
+        value: result.value,
+        reason: result.reason,
+        error: result.err,
+        flagId: result.flagId,
+        companyId: ids?.companyId,
+        userId: ids?.userId,
+        ruleId: ids?.ruleId,
+        reqCompany: evalCtx.company,
+        reqUser: evalCtx.user,
+    });
+    return result;
+}
+
+/**
+ * Drives a single `client.check` with `usage` set.
+ *
+ * Steps:
+ *   1. Resolve the matching credit-balance condition on the flag to get
+ *      `creditId` + `consumptionRate`.
+ *   2. Acquire (or reuse) a lease for `(company, creditId)`.
+ *   3. Try to reserve `quantity × consumptionRate` from the lease.
+ *   4. Run the WASM rules engine against a substituted company snapshot
+ *      (`credit_balances[creditId] = lease.localRemaining` *before* the
+ *      reservation we just made was debited), plus `event_usage` options so
+ *      the engine evaluates the post-call balance. The reservation we made
+ *      in step 3 only sticks if the engine says allowed.
+ */
+export async function checkWithLease(
+    deps: CreditCheckDeps,
+    key: string,
+    evalCtx: api.CheckFlagRequestBody,
+    options: CheckOptions,
+    fallback: () => Promise<CheckResult>,
+): Promise<CheckResult> {
+    const { datastream, leaseStore, reservations, manager, logger } = deps;
+    const onFailure = options.onAcquireFailure ?? "fail-closed";
+
+    // A malformed `usage` must never reach the stores: NaN slips through every
+    // numeric comparison (`NaN <= 0` and `balance < NaN` are both false), so a
+    // single NaN debit would silently poison the — possibly shared — lease
+    // balance into approving every subsequent reserve until the lease is
+    // replaced. The stores also guard individually, but resolve it here
+    // through the caller's fail-open/fail-closed contract instead of letting
+    // it surface as an opaque reserve failure.
+    if (options.usage === undefined || !Number.isFinite(options.usage) || options.usage < 0) {
+        logger.error(
+            `Lease check: invalid usage ${options.usage} for flag ${key} — must be a finite, non-negative number`,
+        );
+        return emitFlagCheck(deps, evalCtx, staticFailureResult(onFailure, key, "invalid_usage", null));
+    }
+
+    // Zero usage means nothing to reserve — use the plain check (preflight
+    // still threaded) instead of issuing a no-op 0-credit handle.
+    if (options.usage === 0) {
+        logger.debug(`Lease check: usage is 0 for flag ${key} — nothing to reserve, using plain check`);
+        return fallback();
+    }
+
+    if (!datastream) {
+        logger.debug("Credit-lease check requested without datastream — falling back to plain check");
+        return fallback();
+    }
+
+    let flag: api.RulesengineFlag | null = null;
+    try {
+        flag = await datastream.getFlag(key);
+    } catch (err) {
+        logger.warn(`Lease check: failed to load flag ${key}: ${err}`);
+    }
+    if (!flag) {
+        logger.debug(`Lease check: no cached flag for ${key}, falling back`);
+        return fallback();
+    }
+
+    const { eventSubtype, quantity } = extractPreflightQuantity(options);
+
+    if (!evalCtx.company) {
+        logger.debug("Lease check: no company on evalCtx, falling back");
+        return fallback();
+    }
+
+    // Resolve company + user the same way a plain datastream flag check does:
+    // cache-first, then a live fetch over the WS that waits for the entity to
+    // stream back. Evaluating with a missing entity is not an option — a null
+    // user would silently skip user-targeted rules/overrides. If either entity
+    // the caller named can't be resolved (replicator cache miss, WS down),
+    // fall back to the plain check, which has its own degradation story.
+    let company: api.RulesengineCompany | null = null;
+    try {
+        company = await datastream.getCompany(evalCtx.company);
+    } catch (err) {
+        logger.debug(
+            `Lease check: company fetch failed for keys ${JSON.stringify(evalCtx.company)} (${err}), falling back`,
+        );
+    }
+    if (!company) {
+        return fallback();
+    }
+
+    let user: api.RulesengineUser | null = null;
+    if (evalCtx.user) {
+        try {
+            user = await datastream.getUser(evalCtx.user);
+        } catch (err) {
+            logger.debug(
+                `Lease check: user fetch failed for keys ${JSON.stringify(evalCtx.user)} (${err}), falling back`,
+            );
+        }
+        if (!user) {
+            return fallback();
+        }
+    }
+
+    // A flag can carry credit conditions from several plans, each metering a
+    // different credit type. Lease the credit the company's *matched* plan
+    // entitlement actually uses — not whichever credit condition is declared
+    // first on the flag. We can't read that off the flag structurally (a
+    // condition doesn't know which rule the company matched), so we probe the
+    // engine: its entitlement reports the plan-correct creditId regardless of
+    // balance. Falls back to first-match for single-credit flags or when the
+    // probe can't resolve a credit.
+    const match = await resolveCreditCondition(datastream, flag, company, user, eventSubtype, logger);
+    if (!match) {
+        logger.debug(
+            `Lease check: flag ${key} has no matching credit condition (subtype=${eventSubtype ?? "<none>"}), falling back`,
+        );
+        return fallback();
+    }
+
+    const creditId = match.condition.creditId;
+    const consumptionRate = match.condition.consumptionRate ?? 0;
+    if (consumptionRate <= 0) {
+        logger.debug(`Lease check: condition has no consumption_rate, falling back`);
+        return fallback();
+    }
+    // The reservation settles into a Track event named by this subtype; an
+    // empty event name would consume the reservation while billing nothing,
+    // so a condition with no resolvable subtype is treated like one with no
+    // consumption_rate.
+    const resolvedSubtype = eventSubtype ?? match.condition.eventSubtype;
+    if (!resolvedSubtype) {
+        logger.debug(`Lease check: credit condition has no event subtype, falling back`);
+        return fallback();
+    }
+    const creditCost = quantity * consumptionRate;
+
+    // Thread the caller's per-check timeout to the lease wire calls
+    // (acquire/extend) the same way the fallback path threads it to checkFlag.
+    const requestOptions: CreditsClient.RequestOptions | undefined =
+        options.timeoutMs !== undefined ? { timeoutInSeconds: options.timeoutMs / 1000 } : undefined;
+
+    // Every can't-gate outcome — wire failure, store (Redis) failure,
+    // exhausted lease — funnels through here so the fail-open/fail-closed
+    // contract holds even when the backing infrastructure is down.
+    const failure = (reason: string): Promise<CheckResult> =>
+        handleLeaseFailure({
+            datastream,
+            logger,
+            mode: onFailure,
+            key,
+            reason,
+            flag,
+            company,
+            user,
+            creditId,
+            options,
+        }).then((result) => emitFlagCheck(deps, evalCtx, result, { companyId: company.id, userId: user?.id }));
+
+    const lease = await manager.acquireIfNeeded(company.id, creditId, requestOptions);
+    if (!lease) {
+        return failure("lease_acquire_failed");
+    }
+
+    // `tryReserve` is the atomic gate: check-and-debit in one step, returning
+    // the post-debit balance on success (so we can derive the pre-debit figure
+    // below without a follow-up store read).
+    let postReserveBalance: number | null;
+    try {
+        postReserveBalance = await leaseStore.tryReserve(company.id, creditId, creditCost);
+        if (postReserveBalance === null) {
+            // Lease has less than `creditCost` left locally. Pass `creditCost` so
+            // `maybeExtendInBackground` extends even when the ratio is still above
+            // the low-watermark (e.g. a single large request).
+            await manager.maybeExtendInBackground(company.id, creditId, creditCost, requestOptions);
+            postReserveBalance = await leaseStore.tryReserve(company.id, creditId, creditCost);
+        }
+    } catch (err) {
+        logger.error(`Lease check: reserve against ${company.id}/${creditId} failed: ${err}`);
+        return failure("lease_store_error");
+    }
+    if (postReserveBalance === null) {
+        return failure("insufficient_lease_balance");
+    }
+
+    // Record the reservation *before* the WASM eval. The debit above and this
+    // record are two steps; persisting the hold first means a crash between
+    // them leaves a sweepable reservation (refunded at its TTL) rather than
+    // stranding the debited credits until the whole lease expires. The
+    // remaining unprotected window is just the gap between the debit and this
+    // add (no I/O in between); a crash there leaks at most `creditCost` until
+    // the lease's own expiry reclaims it server-side.
+    const reservation = registerReservation({
+        leaseId: lease.leaseId,
+        companyId: company.id,
+        creditTypeId: creditId,
+        eventSubtype: resolvedSubtype,
+        quantityReserved: quantity,
+        creditsReserved: creditCost,
+        consumptionRate,
+        reservationTTL: resolveReservationTTL(deps, creditId),
+        evalCtx,
+    });
+
+    try {
+        await reservations.add(reservation);
+    } catch (err) {
+        logger.error(`Lease check: failed to persist reservation ${reservation.id}: ${err}`);
+        // Undo the local debit so the credits aren't stranded until lease
+        // expiry. `consume` claims whatever slice of `add` made it to the
+        // store and refunds it; if nothing was persisted (`null`), refund the
+        // debit directly. Both pinned to this lease. If even the undo fails,
+        // accept the bounded leak — the slice is reclaimed when the lease
+        // expires server-side, which beats risking a double refund.
+        try {
+            const undone = await reservations.consume(reservation.id, 0);
+            if (undone === null) {
+                await leaseStore.refund(company.id, creditId, creditCost, lease.leaseId);
+            }
+        } catch (undoErr) {
+            logger.warn(
+                `Lease check: could not undo local debit for ${reservation.id} (${undoErr}); the slice is reclaimed at lease expiry`,
+            );
+        }
+        return failure("lease_store_error");
+    }
+
+    // Substitute the lease balance into the company snapshot so the engine
+    // gates against the lease's local view, not the server's authoritative
+    // balance. We use the *pre-reservation* localRemaining + event_usage so
+    // the engine computes `pre - qty*rate >= 0` — the same arithmetic
+    // `tryReserve` just enforced. Pre-reservation = the post-debit balance the
+    // atomic reserve returned + the creditCost it debited — exact as of the
+    // debit, no read race.
+    const preReservation = postReserveBalance + creditCost;
+    const substituted = substituteCreditBalance(company, creditId, preReservation);
+
+    const wasmOptions = buildPreflightOptions(options);
+    let result;
+    try {
+        result = await datastream.getRulesEngine().checkFlagWithOptions(flag, substituted, user ?? null, wasmOptions);
+    } catch (err) {
+        logger.error(`Lease check: WASM eval failed: ${err}`);
+        // Cancel the hold: removes the reservation record and refunds the full
+        // reserved amount back to the lease in one atomic step. The engine
+        // itself just failed, so skip the fail-open re-eval and resolve the
+        // mode statically.
+        await cancelReservation(reservations, reservation, logger);
+        return emitFlagCheck(deps, evalCtx, staticFailureResult(onFailure, key, `wasm_error: ${err}`, flag), {
+            companyId: company.id,
+            userId: user?.id,
+        });
+    }
+
+    // Engine-evaluated exits report the engine's resolved ids, mirroring the
+    // plain datastream path's flag_check event.
+    const ids = {
+        companyId: result.companyId ?? company.id,
+        userId: result.userId ?? user?.id,
+        ruleId: result.ruleId,
+    };
+
+    if (!result.value) {
+        await cancelReservation(reservations, reservation, logger);
+        return emitFlagCheck(
+            deps,
+            evalCtx,
+            {
+                allowed: false,
+                value: false,
+                reason: result.reason ?? "denied_by_engine",
+                entitlement: normalizeEntitlement(result.entitlement),
+                flagKey: result.flagKey ?? key,
+                flagId: result.flagId,
+            },
+            ids,
+        );
+    }
+
+    // The engine allowed — but keep the hold only if the allow actually came
+    // from the rule whose credit condition we reserved against. An allow via a
+    // different rule (company/global override, another plan's rule) grants the
+    // feature without metering this credit, so keeping the reservation would
+    // bill usage the matched rule grants for free. Cancel it and return the
+    // allow without a handle — `trackWithReservation` is never owed. Only a
+    // definitive mismatch cancels: if the engine doesn't report a ruleId, the
+    // reservation is kept rather than silently disabling credit gating.
+    if (result.ruleId !== undefined && result.ruleId !== match.ruleId) {
+        logger.debug(
+            `Lease check: flag ${key} allowed by rule ${result.ruleId} (${result.ruleType ?? "unknown type"}), ` +
+                `not the credit-metered rule ${match.ruleId} — cancelling reservation, no credits billed`,
+        );
+        await cancelReservation(reservations, reservation, logger);
+        return emitFlagCheck(
+            deps,
+            evalCtx,
+            {
+                allowed: true,
+                value: true,
+                reason: result.reason ?? "allowed_without_credit_rule",
+                entitlement: normalizeEntitlement(result.entitlement),
+                flagKey: result.flagKey ?? key,
+                flagId: result.flagId,
+            },
+            ids,
+        );
+    }
+
+    // Fire-and-forget low-water-mark refresh now that we've debited.
+    void manager.maybeExtendInBackground(company.id, creditId);
+
+    return emitFlagCheck(
+        deps,
+        evalCtx,
+        {
+            allowed: true,
+            value: true,
+            reservation,
+            reason: result.reason ?? "lease_reserved",
+            entitlement: normalizeEntitlement(result.entitlement),
+            flagKey: result.flagKey ?? key,
+            flagId: result.flagId,
+        },
+        ids,
+    );
+}
+
+function resolveReservationTTL(deps: CreditCheckDeps, creditId: string): ResolvedLeaseConfig {
+    return deps.manager.resolveConfig(creditId);
+}
+
+function extractPreflightQuantity(options: CheckOptions): {
+    eventSubtype: string | undefined;
+    quantity: number;
+} {
+    return { eventSubtype: options.eventSubtype, quantity: options.usage ?? 0 };
+}
+
+/**
+ * Build the preflight options envelope for a client-side rules evaluation.
+ * With an `eventSubtype` the quantity goes out as the `event_usage` pair so
+ * the engine matches it to the subtype's condition; without one it goes out
+ * as the generic `usage` knob. Exported so `client.check`'s fallback path can
+ * thread the same preflight through a plain flag check — any client-side
+ * evaluation (datastream, replicator) honors it even when the lease path
+ * can't run.
+ */
+export function buildPreflightOptions(options: CheckOptions): CheckFlagOptions | undefined {
+    if (options.usage === undefined) return undefined;
+    if (options.eventSubtype !== undefined) {
+        return { eventUsage: { eventSubtype: options.eventSubtype, quantity: options.usage } };
+    }
+    return { usage: options.usage };
+}
+
+interface CreditConditionMatch {
+    condition: api.RulesengineCondition & { creditId: string };
+    /**
+     * Id of the rule the condition belongs to. After the gating eval, the
+     * reservation is kept only if the engine's matched `ruleId` is this rule —
+     * an allow via a different rule (company/global override, another plan's
+     * rule) grants the feature without metering this credit, so the hold is
+     * cancelled instead of billed.
+     */
+    ruleId: string;
+}
+
+/**
+ * Resolve the credit condition to lease against. A flag can declare credit
+ * conditions for several credit types — one per plan that entitles the feature
+ * — and the right one for this company is the credit its *matched* plan
+ * entitlement uses, which only the rules engine knows.
+ *
+ * When the flag meters this event subtype in a single credit type (the common
+ * case) the first matching condition is unambiguous and we return it directly,
+ * with no extra engine call. Only when conditions disagree on credit type do
+ * we probe: the engine's `entitlement.creditId` names the company's metered
+ * credit regardless of balance, and we select that credit's condition to read
+ * its `consumption_rate`. A probe that can't resolve a credit (non-credit
+ * entitlement or an error) falls back to first-match, preserving prior
+ * behavior.
+ */
+async function resolveCreditCondition(
+    datastream: DataStreamClient,
+    flag: api.RulesengineFlag,
+    company: api.RulesengineCompany,
+    user: object | null,
+    eventSubtype: string | undefined,
+    logger: Logger,
+): Promise<CreditConditionMatch | null> {
+    const first = findCreditCondition(flag, eventSubtype);
+    if (!first) return null;
+    if (collectCreditIds(flag, eventSubtype).size <= 1) return first;
+
+    try {
+        const probe = await datastream.getRulesEngine().checkFlagWithOptions(flag, company, user, null);
+        const creditId = probe.entitlement?.creditId;
+        if (creditId) {
+            const byCredit = findCreditCondition(flag, eventSubtype, creditId);
+            if (byCredit) return byCredit;
+            logger.debug(
+                `Lease check: entitlement credit ${creditId} has no matching condition on flag, falling back to first credit condition`,
+            );
+        }
+    } catch (err) {
+        logger.warn(`Lease check: credit-resolution probe failed (${err}), falling back to first credit condition`);
+    }
+    return first;
+}
+
+/** Distinct credit-type ids across the flag's credit conditions for `eventSubtype`. */
+function collectCreditIds(flag: api.RulesengineFlag, eventSubtype: string | undefined): Set<string> {
+    const ids = new Set<string>();
+    const scan = (conditions: api.RulesengineCondition[]) => {
+        for (const c of conditions) {
+            if (c.conditionType !== "credit" || !c.creditId) continue;
+            if (eventSubtype !== undefined && c.eventSubtype !== eventSubtype) continue;
+            ids.add(c.creditId);
+        }
+    };
+    for (const rule of flag.rules ?? []) {
+        scan(rule.conditions ?? []);
+        for (const group of rule.conditionGroups ?? []) scan(group.conditions ?? []);
+    }
+    return ids;
+}
+
+function findCreditCondition(
+    flag: api.RulesengineFlag,
+    eventSubtype: string | undefined,
+    creditId?: string,
+): CreditConditionMatch | null {
+    for (const rule of flag.rules ?? []) {
+        const inRule = matchInConditions(rule.conditions ?? [], eventSubtype, creditId);
+        if (inRule) return { ...inRule, ruleId: rule.id };
+        for (const group of rule.conditionGroups ?? []) {
+            const inGroup = matchInConditions(group.conditions ?? [], eventSubtype, creditId);
+            if (inGroup) return { ...inGroup, ruleId: rule.id };
+        }
+    }
+    return null;
+}
+
+function matchInConditions(
+    conditions: api.RulesengineCondition[],
+    eventSubtype: string | undefined,
+    creditId?: string,
+): Omit<CreditConditionMatch, "ruleId"> | null {
+    for (const c of conditions) {
+        if (c.conditionType !== "credit") continue;
+        if (!c.creditId) continue;
+        if (eventSubtype !== undefined && c.eventSubtype !== eventSubtype) continue;
+        if (creditId !== undefined && c.creditId !== creditId) continue;
+        return { condition: c as api.RulesengineCondition & { creditId: string } };
+    }
+    return null;
+}
+
+function substituteCreditBalance(
+    company: api.RulesengineCompany,
+    creditId: string,
+    balance: number,
+): api.RulesengineCompany {
+    return {
+        ...company,
+        creditBalances: {
+            ...(company.creditBalances ?? {}),
+            [creditId]: balance,
+        },
+    };
+}
+
+function registerReservation(args: {
+    leaseId: string;
+    companyId: string;
+    creditTypeId: string;
+    eventSubtype: string;
+    quantityReserved: number;
+    creditsReserved: number;
+    consumptionRate: number;
+    reservationTTL: ResolvedLeaseConfig;
+    evalCtx: api.CheckFlagRequestBody;
+}): Reservation {
+    return {
+        id: randomUUID(),
+        leaseId: args.leaseId,
+        companyId: args.companyId,
+        creditTypeId: args.creditTypeId,
+        eventSubtype: args.eventSubtype,
+        quantityReserved: args.quantityReserved,
+        creditsReserved: args.creditsReserved,
+        consumptionRate: args.consumptionRate,
+        expiresAt: new Date(Date.now() + args.reservationTTL.reservationTTL),
+        evalCtx: args.evalCtx,
+    };
+}
+
+function normalizeEntitlement(raw: WasmFeatureEntitlement | undefined): api.RulesengineFeatureEntitlement | undefined {
+    if (!raw) return undefined;
+    return {
+        ...raw,
+        metricResetAt: raw.metricResetAt ? new Date(raw.metricResetAt) : undefined,
+    };
+}
+
+/** Best-effort reservation cancel: claims the record and refunds its full hold. */
+async function cancelReservation(
+    reservations: IReservationStore,
+    reservation: Reservation,
+    logger: Logger,
+): Promise<void> {
+    try {
+        await reservations.consume(reservation.id, 0);
+    } catch (err) {
+        logger.warn(
+            `Lease check: failed to cancel reservation ${reservation.id} (${err}); its hold is reclaimed by the sweeper or at lease expiry`,
+        );
+    }
+}
+
+// Balance substituted for the fail-open evaluation: large enough that the
+// credit gate always passes, finite so it serializes cleanly to the WASM.
+const FAIL_OPEN_BALANCE = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Resolve a can't-gate outcome (lease acquire failed, store unreachable,
+ * lease exhausted) according to the configured mode.
+ *
+ * `fail-closed` denies outright. `fail-open` means "err on the side of
+ * assuming the credits are there" — NOT "skip evaluation": the rules engine
+ * still runs with the credit balance substituted to an effectively unlimited
+ * value, so plan targeting, company/user overrides, and every non-credit
+ * condition still apply. A company that isn't entitled to the feature stays
+ * denied even when the lease backend is down. Only if that evaluation itself
+ * errors do we fall back to a blanket allow.
+ */
+async function handleLeaseFailure(args: {
+    datastream: DataStreamClient;
+    logger: Logger;
+    mode: OnAcquireFailure;
+    key: string;
+    reason: string;
+    flag: api.RulesengineFlag;
+    company: api.RulesengineCompany;
+    user: api.RulesengineUser | null;
+    creditId: string;
+    options: CheckOptions;
+}): Promise<CheckResult> {
+    const { datastream, logger, mode, key, reason, flag, company, user, creditId, options } = args;
+    if (mode === "fail-closed") {
+        return staticFailureResult(mode, key, reason, flag);
+    }
+
+    try {
+        const substituted = substituteCreditBalance(company, creditId, FAIL_OPEN_BALANCE);
+        const result = await datastream
+            .getRulesEngine()
+            .checkFlagWithOptions(flag, substituted, user, buildPreflightOptions(options));
+        return {
+            allowed: result.value,
+            value: result.value,
+            reason: `${result.reason ?? "evaluated"} (${reason}_fail_open)`,
+            entitlement: normalizeEntitlement(result.entitlement),
+            flagKey: result.flagKey ?? key,
+            flagId: result.flagId ?? flag.id,
+            err: reason,
+        };
+    } catch (err) {
+        logger.warn(`Lease check: fail-open evaluation failed (${err}); allowing`);
+        return staticFailureResult(mode, key, reason, flag);
+    }
+}
+
+/**
+ * Mode resolved without an engine evaluation: deny for fail-closed, blanket
+ * allow for fail-open. Used directly when the engine itself is the thing
+ * that failed, and as the fallback when the fail-open evaluation errors.
+ */
+function staticFailureResult(
+    mode: OnAcquireFailure,
+    flagKey: string,
+    reason: string,
+    flag: api.RulesengineFlag | null,
+): CheckResult {
+    if (mode === "fail-closed") {
+        return {
+            allowed: false,
+            value: false,
+            reason,
+            flagKey,
+            flagId: flag?.id,
+            err: reason,
+        };
+    }
+    return {
+        allowed: true,
+        value: true,
+        reason: `${reason}_fail_open`,
+        flagKey,
+        flagId: flag?.id,
+        err: reason,
+    };
+}

--- a/src/credits/index.ts
+++ b/src/credits/index.ts
@@ -1,0 +1,23 @@
+export { LeaseStore, leaseKey, type LeaseEntry, type ILeaseStore } from "./lease-store";
+export { ReservationStore, type IReservationStore } from "./reservation-store";
+export { CreditLeaseManager } from "./lease-manager";
+export { RedisLeaseStore } from "./redis-lease-store";
+export { RedisReservationStore } from "./redis-reservation-store";
+export {
+    DEFAULT_LEASE_DURATION_MS,
+    DEFAULT_LEASE_SIZE,
+    DEFAULT_LOW_WATER_MARK,
+    DEFAULT_PREWARM_POLL_INTERVAL_MS,
+    DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS,
+    DEFAULT_RESERVATION_TTL_MS,
+    DEFAULT_SWEEP_INTERVAL_MS,
+} from "./types";
+export type {
+    CreditLeaseConfig,
+    ResolvedLeaseConfig,
+    Reservation,
+    CheckOptions,
+    CheckResult,
+    OnAcquireFailure,
+    TrackWithReservationOptions,
+} from "./types";

--- a/src/credits/lease-manager.ts
+++ b/src/credits/lease-manager.ts
@@ -1,0 +1,301 @@
+import type * as api from "../api";
+import type { CreditsClient } from "../api/resources/credits/client/Client";
+import type { Logger } from "../logger";
+
+import { type ILeaseStore, type LeaseEntry, leaseKey } from "./lease-store";
+import {
+    DEFAULT_LEASE_DURATION_MS,
+    DEFAULT_LEASE_SIZE,
+    DEFAULT_LOW_WATER_MARK,
+    DEFAULT_RESERVATION_TTL_MS,
+    type CreditLeaseConfig,
+    type ResolvedLeaseConfig,
+} from "./types";
+
+/**
+ * Owns the lifecycle of `credit_lease` rows for a single client: acquire on
+ * first use or after expiry, extend when the local view dips below the low
+ * water mark, release on `client.close()`.
+ *
+ * Concurrency: each operation (acquire, extend) has its own best-effort
+ * single-flight map keyed by `(company, creditType)`. It's best-effort —
+ * callers racing ahead of the registration can still issue duplicate wire
+ * calls — which is safe because the server is idempotent for an active slot
+ * and `replace` keeps the first live lease.
+ */
+export class CreditLeaseManager {
+    private readonly creditsClient: CreditsClient;
+    private readonly leaseStore: ILeaseStore;
+    private readonly logger: Logger;
+    private readonly config: CreditLeaseConfig;
+    // Kept separate so acquire and extend never share an in-flight promise.
+    private readonly inflightAcquire = new Map<string, Promise<LeaseEntry | undefined>>();
+    private readonly inflightExtend = new Map<string, Promise<LeaseEntry | undefined>>();
+
+    constructor(opts: {
+        creditsClient: CreditsClient;
+        leaseStore: ILeaseStore;
+        logger: Logger;
+        config: CreditLeaseConfig;
+    }) {
+        this.creditsClient = opts.creditsClient;
+        this.leaseStore = opts.leaseStore;
+        this.logger = opts.logger;
+        this.config = opts.config;
+    }
+
+    resolveConfig(creditTypeId: string): ResolvedLeaseConfig {
+        const override = this.config.overrides?.[creditTypeId];
+        return {
+            leaseDuration:
+                override?.defaultLeaseDuration ?? this.config.defaultLeaseDuration ?? DEFAULT_LEASE_DURATION_MS,
+            reservationTTL:
+                override?.defaultReservationTTL ?? this.config.defaultReservationTTL ?? DEFAULT_RESERVATION_TTL_MS,
+            leaseSize: override?.defaultLeaseSize ?? this.config.defaultLeaseSize ?? DEFAULT_LEASE_SIZE,
+            lowWaterMark: override?.lowWaterMark ?? this.config.lowWaterMark ?? DEFAULT_LOW_WATER_MARK,
+        };
+    }
+
+    /**
+     * Return the current lease entry, acquiring one (or replacing an expired
+     * one) if none is live. Best-effort single-flight: callers arriving after
+     * a request is registered share it (the first caller's `requestOptions`
+     * win); callers racing ahead of registration may duplicate the wire call,
+     * which the server's idempotent acquire absorbs.
+     * Never rejects: a store (Redis) failure is logged and reported as
+     * `undefined`, the same as a wire failure, so callers route it through
+     * their fail-open/fail-closed handling instead of an unhandled rejection.
+     */
+    async acquireIfNeeded(
+        companyId: string,
+        creditTypeId: string,
+        requestOptions?: CreditsClient.RequestOptions,
+    ): Promise<LeaseEntry | undefined> {
+        let existing: LeaseEntry | undefined;
+        try {
+            existing = await this.leaseStore.get(companyId, creditTypeId);
+        } catch (err) {
+            this.logger.error(`Failed to read lease store for ${companyId}/${creditTypeId}: ${err}`);
+            return undefined;
+        }
+        if (existing && existing.expiresAt.getTime() > Date.now()) {
+            return existing;
+        }
+        // An expired (or absent) slot is left for `replace` to overwrite — it
+        // guards on expiry and does the DEL+write atomically (single Lua exec
+        // in Redis, single lock in memory). We deliberately do NOT drop the
+        // stale entry here first: a standalone DEL is a separate, non-atomic op
+        // that can interleave between a sibling pod's `get` and its `replace`,
+        // clobbering a lease that pod just installed and orphaning it until
+        // server-side expiry. Reading a stale entry in the gap is harmless —
+        // every mutate/read path (`tryReserve`, `getCreditBalance`) already
+        // guards on expiry. The server treats an expired lease as released and
+        // refunds the full grant back to the company balance.
+
+        const key = leaseKey(companyId, creditTypeId);
+        const inflight = this.inflightAcquire.get(key);
+        if (inflight) return inflight;
+
+        const promise = this.acquire(companyId, creditTypeId, requestOptions).finally(() => {
+            this.inflightAcquire.delete(key);
+        });
+        this.inflightAcquire.set(key, promise);
+        return promise;
+    }
+
+    private async acquire(
+        companyId: string,
+        creditTypeId: string,
+        requestOptions?: CreditsClient.RequestOptions,
+    ): Promise<LeaseEntry | undefined> {
+        const resolved = this.resolveConfig(creditTypeId);
+        const body: api.AcquireCreditLeaseRequestBody = {
+            companyId,
+            creditTypeId,
+            requestedAmount: resolved.leaseSize,
+            expiresAt: new Date(Date.now() + resolved.leaseDuration),
+        };
+
+        try {
+            const response = await this.creditsClient.acquireCreditLease(body, requestOptions);
+            const data = response.data;
+            const wrote = await this.leaseStore.replace({
+                leaseId: data.id,
+                companyId: data.companyId,
+                creditTypeId: data.creditTypeId,
+                grantedAmount: data.grantedAmount,
+                expiresAt: data.expiresAt,
+            });
+            if (!wrote) {
+                // Another instance (sharing the backend) installed a live lease
+                // for this slot first — `replace` kept theirs to preserve its
+                // already-debited balance. The server is idempotent for an
+                // active (company, creditType) slot, so a racing acquire is
+                // normally handed back the SAME lease the sibling installed
+                // (`reused_active`) — in which case there is nothing to
+                // release: releasing would mark the shared lease released
+                // server-side and refund its remainder while every pod keeps
+                // reserving against it locally, over-spending until the local
+                // row expires. Only when the server minted a *different* lease
+                // (e.g. the sibling's lease replaced one that expired during
+                // our wire call) is ours a redundant hold nobody will draw on
+                // — release that one so it isn't orphaned against the
+                // company's balance until its server-side expiry.
+                // Fire-and-forget; a failed release just falls back to lease
+                // expiry. When the slot reads empty (expired in the gap), skip
+                // the release too — `data.id` may well be the lease the next
+                // acquire is handed back.
+                const current = await this.leaseStore.get(companyId, creditTypeId);
+                if (current && current.leaseId !== data.id) {
+                    this.logger.debug(
+                        `Lost acquire race for ${companyId}/${creditTypeId}; releasing redundant lease ${data.id}`,
+                    );
+                    void this.creditsClient
+                        .releaseCreditLease(data.id, {})
+                        .catch((err) =>
+                            this.logger.warn(`Failed to release redundant credit lease ${data.id}: ${err}`),
+                        );
+                } else {
+                    this.logger.debug(
+                        `Lost acquire race for ${companyId}/${creditTypeId}; server returned the installed lease ${data.id}, nothing to release`,
+                    );
+                }
+                return current;
+            } else {
+                this.logger.debug(
+                    `Acquired credit lease ${data.id} for ${companyId}/${creditTypeId} (granted=${data.grantedAmount}, expires=${data.expiresAt.toISOString()})`,
+                );
+            }
+            return await this.leaseStore.get(companyId, creditTypeId);
+        } catch (err) {
+            this.logger.error(`Failed to acquire credit lease for ${companyId}/${creditTypeId}: ${err}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Single-flight: kick off a background extend when one is warranted.
+     * An extend is triggered if EITHER:
+     *   - the local remaining is below the low-water-mark ratio (steady-state
+     *     refresh), or
+     *   - the caller passes `requiredCredits` and the local remaining is below
+     *     that figure (a single check just failed a reserve for that many
+     *     credits — extend opportunistically instead of waiting for the next
+     *     sub-watermark check).
+     * Returns the in-flight promise so callers can await it or fire-and-forget.
+     * Never rejects (it is often fire-and-forget — a rejection would surface
+     * as an unhandled promise rejection).
+     */
+    async maybeExtendInBackground(
+        companyId: string,
+        creditTypeId: string,
+        requiredCredits?: number,
+        requestOptions?: CreditsClient.RequestOptions,
+    ): Promise<LeaseEntry | undefined> {
+        let entry: LeaseEntry | undefined;
+        try {
+            entry = await this.leaseStore.get(companyId, creditTypeId);
+        } catch (err) {
+            this.logger.warn(`Failed to read lease store for ${companyId}/${creditTypeId}: ${err}`);
+            return undefined;
+        }
+        if (!entry) return undefined;
+        // Never extend an expired lease: the server treats it as released (its
+        // remainder already refunded to the company balance), so the right
+        // move is a fresh acquire, which the next check's `acquireIfNeeded`
+        // performs. Extending would at best waste a wire call and at worst
+        // resurrect a stale local row.
+        if (entry.expiresAt.getTime() <= Date.now()) return undefined;
+        const resolved = this.resolveConfig(creditTypeId);
+        const ratio = entry.localRemainingCredits / Math.max(entry.grantedAmount, 1);
+        const belowWatermark = ratio <= resolved.lowWaterMark;
+        const belowRequired = requiredCredits !== undefined && entry.localRemainingCredits < requiredCredits;
+        if (!belowWatermark && !belowRequired) return entry;
+
+        const key = leaseKey(companyId, creditTypeId);
+        const inflight = this.inflightExtend.get(key);
+        if (inflight) return inflight;
+
+        const promise = this.extend(entry, resolved, requiredCredits, requestOptions).finally(() => {
+            this.inflightExtend.delete(key);
+        });
+        this.inflightExtend.set(key, promise);
+        return promise;
+    }
+
+    private async extend(
+        entry: LeaseEntry,
+        resolved: ResolvedLeaseConfig,
+        requiredCredits?: number,
+        requestOptions?: CreditsClient.RequestOptions,
+    ): Promise<LeaseEntry | undefined> {
+        // Size the extend to cover the request that triggered it: a single
+        // check needing more than `localRemaining + leaseSize` would otherwise
+        // fail its post-extend retry forever, even with ample server balance.
+        // The watermark-driven steady-state path (no requiredCredits) keeps
+        // requesting the configured tranche.
+        const shortfall = requiredCredits !== undefined ? requiredCredits - entry.localRemainingCredits : 0;
+        const body: api.ExtendCreditLeaseRequestBody = {
+            additionalAmount: Math.max(resolved.leaseSize, shortfall),
+            expiresAt: new Date(Date.now() + resolved.leaseDuration),
+        };
+        try {
+            const response = await this.creditsClient.extendCreditLease(entry.leaseId, body, requestOptions);
+            const data = response.data;
+            // Reconcile the local row to the server's authoritative TOTAL. The
+            // store computes the credit delta atomically against its current
+            // total — not our pre-wire-call `entry` read: per-process
+            // single-flight doesn't cover sibling pods, so two pods extending
+            // the same shared lease concurrently would each apply a stale-read
+            // delta and mint phantom credits. A total a sibling already
+            // applied lands as a no-op, so the applies converge in any order.
+            // Pinned to the lease the server extended: if it expired during
+            // the wire call and a successor took the slot, the local extend
+            // is dropped rather than minting the delta onto the successor.
+            await this.leaseStore.extend(
+                entry.companyId,
+                entry.creditTypeId,
+                data.grantedAmount,
+                data.expiresAt,
+                entry.leaseId,
+            );
+            this.logger.debug(
+                `Extended credit lease ${entry.leaseId} to ${data.grantedAmount} (was ${entry.grantedAmount} at last read, expires ${data.expiresAt.toISOString()})`,
+            );
+            return await this.leaseStore.get(entry.companyId, entry.creditTypeId);
+        } catch (err) {
+            this.logger.warn(`Failed to extend credit lease ${entry.leaseId}: ${err}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Release every live lease held in the store. ONLY safe when the store is
+     * per-process (in-memory): those leases are exclusively this process's, so
+     * releasing them on `close()` returns their unspent remainder to the
+     * company balance immediately instead of waiting out the lease expiry. A
+     * shared (Redis) store must never do this — sibling pods are still
+     * drawing on the same leases — and is excluded by the `list` capability
+     * check (only the in-memory store implements it). Best-effort: failures
+     * are logged and the lease falls back to server-side expiry.
+     */
+    async releaseAllLocalLeases(): Promise<void> {
+        const entries = this.leaseStore.list?.();
+        if (!entries || entries.length === 0) return;
+        await Promise.all(
+            entries.map(async (entry) => {
+                // Skip expired leases: the server already swept and refunded them.
+                if (entry.expiresAt.getTime() <= Date.now()) return;
+                try {
+                    await this.creditsClient.releaseCreditLease(entry.leaseId, {});
+                    await this.leaseStore.drop(entry.companyId, entry.creditTypeId);
+                    this.logger.debug(`Released credit lease ${entry.leaseId} on close`);
+                } catch (err) {
+                    this.logger.warn(
+                        `Failed to release credit lease ${entry.leaseId} on close (it will expire server-side): ${err}`,
+                    );
+                }
+            }),
+        );
+    }
+}

--- a/src/credits/lease-store.ts
+++ b/src/credits/lease-store.ts
@@ -1,0 +1,246 @@
+/**
+ * In-memory lease store, keyed by `${companyId}:${creditTypeId}`.
+ *
+ * Holds the lease ID, original granted amount, expiry, and the SDK's local
+ * view of `localRemainingCredits` — the portion of the lease not yet reserved
+ * by an outstanding reservation. Per-key serialization (Promise chain) keeps
+ * reserve / refund / replace atomic without external locking.
+ *
+ * The store doesn't talk to the API directly; `CreditLeaseManager` drives
+ * acquire/extend/release through the wire client and uses these methods to
+ * mirror remote state locally.
+ *
+ * For cross-pod deployments, swap this for `RedisLeaseStore` — both
+ * implement `ILeaseStore`.
+ */
+
+export interface LeaseEntry {
+    leaseId: string;
+    companyId: string;
+    creditTypeId: string;
+    grantedAmount: number;
+    localRemainingCredits: number;
+    expiresAt: Date;
+}
+
+/** Backing-store contract shared by `LeaseStore` (in-memory) and `RedisLeaseStore` (shared). */
+export interface ILeaseStore {
+    get(companyId: string, creditTypeId: string): Promise<LeaseEntry | undefined> | LeaseEntry | undefined;
+    /**
+     * Install a fresh lease for the slot, but only if no live lease already
+     * occupies it. Implementations must be safe against concurrent writers
+     * sharing the backend: if a live (unexpired) lease is already present —
+     * even one with a different `leaseId`, e.g. acquired by a sibling pod that
+     * raced this one — leave it untouched so its already-debited
+     * `localRemainingCredits` wins. Returns `true` if it wrote a fresh row,
+     * `false` if it kept an existing live lease (the caller should release the
+     * lease it acquired ONLY if its ID differs from the installed one — the
+     * server hands a racing acquire the same active lease back, and releasing
+     * that would pull the shared lease out from under every sibling).
+     */
+    replace(entry: Omit<LeaseEntry, "localRemainingCredits">): Promise<boolean>;
+    /**
+     * Reconcile the slot's lease to the server-authoritative `grantedAmount`
+     * total (after a remote extend), crediting the difference to
+     * `localRemainingCredits`. The delta MUST be computed atomically inside
+     * the store against the *current* stored total — never by the caller from
+     * a pre-wire-call read: with a shared backend, two pods extending the same
+     * lease concurrently would each apply a delta against the same stale read
+     * and mint phantom credits. Reconciling to the absolute total converges
+     * regardless of arrival order (a total a sibling already applied lands as
+     * a no-op). `newExpiresAt` only ever moves the expiry forward, so an
+     * out-of-order apply can't shorten a lease a sibling just extended. When
+     * `leaseId` is supplied, the extend applies ONLY if the slot still holds
+     * that lease: the server extended lease A, so its credits must not land on
+     * a successor lease B that replaced A after it expired mid-extend —
+     * crediting B would mint credits locally that the server granted to A
+     * (whose remainder it refunds at A's expiry). Mirrors the pin on `refund`.
+     */
+    extend(
+        companyId: string,
+        creditTypeId: string,
+        grantedAmount: number,
+        newExpiresAt?: Date,
+        leaseId?: string,
+    ): Promise<void>;
+    drop(companyId: string, creditTypeId: string): Promise<void>;
+    /**
+     * Atomically check-and-debit `credits` from the lease's remaining balance.
+     * Returns the post-debit `localRemainingCredits` on success, or `null` if
+     * there is no live lease, the balance is insufficient, or `credits` is not
+     * a finite non-negative number (NaN must never reach the debit — it slips
+     * through every numeric comparison and would poison the balance into
+     * allowing everything). Returning the balance rather than a boolean lets
+     * the caller derive the pre-debit figure (`returned + credits`) without a
+     * follow-up read.
+     */
+    tryReserve(companyId: string, creditTypeId: string, credits: number): Promise<number | null>;
+    /**
+     * Refund credits to the slot's lease balance (clamped at `grantedAmount`).
+     * When `leaseId` is supplied, the refund applies ONLY if the slot still
+     * holds that lease: a reservation carved out of lease A must never inflate
+     * a successor lease B that replaced it after A expired — A's unspent
+     * remainder (including this slice) was already refunded to the company
+     * balance server-side when A expired, so crediting B would double-count.
+     */
+    refund(companyId: string, creditTypeId: string, credits: number, leaseId?: string): Promise<void>;
+    /**
+     * Snapshot of all current entries. Only meaningful (and only implemented)
+     * for the per-process in-memory store, where `close()` releases this
+     * process's exclusively-held leases; a shared backend must NOT enumerate —
+     * sibling pods may still be drawing on those leases.
+     */
+    list?(): LeaseEntry[];
+}
+
+export function leaseKey(companyId: string, creditTypeId: string): string {
+    return `${companyId}:${creditTypeId}`;
+}
+
+export class LeaseStore implements ILeaseStore {
+    private leases = new Map<string, LeaseEntry>();
+    /**
+     * Per-key serializer chain. Each `withLock` appends to the tail so
+     * reserve / refund / replace see consistent intermediate state.
+     */
+    private locks = new Map<string, Promise<unknown>>();
+
+    /** Snapshot of the current entry, or undefined if no active lease. */
+    get(companyId: string, creditTypeId: string): LeaseEntry | undefined {
+        const entry = this.leases.get(leaseKey(companyId, creditTypeId));
+        return entry ? { ...entry } : undefined;
+    }
+
+    /**
+     * Replace (or insert) the lease for the given (company, creditType).
+     * Resets `localRemainingCredits` to `grantedAmount` for a new lease.
+     * If a live lease already occupies the slot — regardless of `leaseId` — it
+     * is left alone so any already-debited `localRemainingCredits` wins.
+     * Returns `true` if a fresh row was written, `false` if an existing live
+     * lease was kept.
+     */
+    async replace(entry: Omit<LeaseEntry, "localRemainingCredits">): Promise<boolean> {
+        const key = leaseKey(entry.companyId, entry.creditTypeId);
+        return this.withLock(key, () => {
+            const existing = this.leases.get(key);
+            if (existing && existing.expiresAt.getTime() > Date.now()) {
+                // A live lease already holds this slot — preserve its
+                // already-debited localRemaining instead of clobbering it.
+                return false;
+            }
+            this.leases.set(key, {
+                ...entry,
+                localRemainingCredits: entry.grantedAmount,
+            });
+            return true;
+        });
+    }
+
+    /**
+     * Reconcile an existing lease to the server-authoritative `grantedAmount`
+     * total (after a remote extend), crediting the difference to
+     * `localRemainingCredits`. The delta is computed against the CURRENT
+     * stored total under the key lock, so concurrent extends converge instead
+     * of double-counting (see `ILeaseStore.extend`). If no lease exists for
+     * the key, this is a no-op (caller should have replaced). When `leaseId`
+     * is given, the extend is dropped if the slot now holds a different lease.
+     */
+    async extend(
+        companyId: string,
+        creditTypeId: string,
+        grantedAmount: number,
+        newExpiresAt?: Date,
+        leaseId?: string,
+    ): Promise<void> {
+        const key = leaseKey(companyId, creditTypeId);
+        return this.withLock(key, () => {
+            const entry = this.leases.get(key);
+            if (!entry) return;
+            if (leaseId !== undefined && entry.leaseId !== leaseId) return;
+            const add = grantedAmount - entry.grantedAmount;
+            if (add > 0) {
+                entry.grantedAmount = grantedAmount;
+                entry.localRemainingCredits += add;
+            }
+            // Expiry only moves forward: an out-of-order apply must not
+            // shorten a lease a concurrent extend already pushed out.
+            if (newExpiresAt && newExpiresAt.getTime() > entry.expiresAt.getTime()) {
+                entry.expiresAt = newExpiresAt;
+            }
+        });
+    }
+
+    /** Drop the lease entry (after a remote release or lazy expiry). */
+    async drop(companyId: string, creditTypeId: string): Promise<void> {
+        const key = leaseKey(companyId, creditTypeId);
+        return this.withLock(key, () => {
+            this.leases.delete(key);
+        });
+    }
+
+    /**
+     * Attempt to reserve `credits` from the local remaining balance.
+     * Returns the post-debit balance on success, `null` if there isn't enough
+     * remaining (see `ILeaseStore.tryReserve`).
+     */
+    async tryReserve(companyId: string, creditTypeId: string, credits: number): Promise<number | null> {
+        // Reject non-finite/negative debits outright: `NaN` passes every `<`
+        // comparison below and `balance -= NaN` would poison the lease into
+        // approving all future reserves (`NaN < x` is always false).
+        if (!Number.isFinite(credits) || credits < 0) return null;
+        const key = leaseKey(companyId, creditTypeId);
+        return this.withLock(key, () => {
+            const entry = this.leases.get(key);
+            if (!entry) return null;
+            // Never reserve against an expired lease: the server treats it as
+            // released and refunds the grant to the company balance, so the
+            // local `localRemainingCredits` is stale. Mirrors the expiry guard
+            // in the Redis store and the lazy expiry in `CreditLeaseManager`.
+            if (entry.expiresAt.getTime() <= Date.now()) return null;
+            if (entry.localRemainingCredits < credits) return null;
+            entry.localRemainingCredits -= credits;
+            return entry.localRemainingCredits;
+        });
+    }
+
+    /**
+     * Refund credits back to the local balance (capped at grantedAmount).
+     * When `leaseId` is given, the refund is dropped if the slot now holds a
+     * different lease (see `ILeaseStore.refund`).
+     */
+    async refund(companyId: string, creditTypeId: string, credits: number, leaseId?: string): Promise<void> {
+        if (credits <= 0) return;
+        const key = leaseKey(companyId, creditTypeId);
+        return this.withLock(key, () => {
+            const entry = this.leases.get(key);
+            if (!entry) return;
+            if (leaseId !== undefined && entry.leaseId !== leaseId) return;
+            entry.localRemainingCredits = Math.min(entry.localRemainingCredits + credits, entry.grantedAmount);
+        });
+    }
+
+    /** Snapshot of all current entries (see `ILeaseStore.list`). */
+    list(): LeaseEntry[] {
+        return Array.from(this.leases.values(), (entry) => ({ ...entry }));
+    }
+
+    private async withLock<T>(key: string, fn: () => T | Promise<T>): Promise<T> {
+        const prev = this.locks.get(key) ?? Promise.resolve();
+        let resolve!: () => void;
+        const next = new Promise<void>((r) => (resolve = r));
+        const chain = prev.then(() => next);
+        this.locks.set(key, chain);
+        await prev;
+        try {
+            return await fn();
+        } finally {
+            resolve();
+            // Best-effort cleanup so the map doesn't grow without bound.
+            // Only delete if we're still the tail — otherwise a later caller
+            // has appended and needs the chain to stay live.
+            if (this.locks.get(key) === chain) {
+                this.locks.delete(key);
+            }
+        }
+    }
+}

--- a/src/credits/redis-lease-store.ts
+++ b/src/credits/redis-lease-store.ts
@@ -1,0 +1,270 @@
+import type { RedisClient } from "../cache/redis";
+
+import { type ILeaseStore, type LeaseEntry, leaseKey } from "./lease-store";
+import { DEFAULT_LEASE_DURATION_MS } from "./types";
+
+const DEFAULT_KEY_PREFIX = "schematic:";
+const LEASE_KEY_NAMESPACE = "credit-lease:";
+// How long after the declared expiry to keep the Redis row around before
+// auto-eviction. Gives the sweeper a window to refund expired reservations
+// before the underlying lease state disappears.
+const LEASE_TTL_GRACE_MS = 60_000;
+
+// Every Lua script below touches exactly ONE key (the lease hash), keeping
+// them safe under Redis Cluster (multi-key scripts spanning slots raise
+// CROSSSLOT). Only the lease hash needs atomic mutation; cross-key
+// bookkeeping uses ordinary single-key commands.
+//
+// Expiry is decided against the *Redis server's* clock (`redis.call('TIME')`),
+// not the calling pod's `Date.now()`: with many pods sharing one lease, local
+// clock skew would let pods disagree on whether the lease is live. The
+// `LEASE_NOW_MS` snippet converts TIME to integer milliseconds (matching the
+// stored `expiresAt`); `redis.replicate_commands()` first, so the
+// non-deterministic TIME read is allowed alongside writes on Redis 5/6.
+const LEASE_NOW_MS = `
+redis.replicate_commands()
+local t = redis.call('TIME')
+local now = (tonumber(t[1]) * 1000) + math.floor(tonumber(t[2]) / 1000)
+`;
+
+/**
+ * Atomic `replace`. Writes the lease hash only when the slot is empty or the
+ * existing lease has expired. Returns "1" on write, "0" if a *live* lease
+ * already occupies the slot — even one with a different `leaseId`, e.g.
+ * installed by a sibling instance that raced this acquire. Keeping the existing
+ * live lease preserves its already-debited `localRemainingCredits`; the caller
+ * should release the lease it acquired only if its ID differs from the
+ * installed one (see `CreditLeaseManager.acquire`). `now` is the Redis server
+ * clock (see `LEASE_NOW_MS`).
+ */
+const REPLACE_SCRIPT =
+    LEASE_NOW_MS +
+    `
+local existing_id = redis.call('HGET', KEYS[1], 'leaseId')
+local existing_expiry = tonumber(redis.call('HGET', KEYS[1], 'expiresAt') or '0')
+local new_id = ARGV[1]
+local new_granted = ARGV[2]
+local new_expiry = tonumber(ARGV[3])
+local grace = tonumber(ARGV[4])
+
+if existing_id and existing_expiry > now then
+    return 0
+end
+
+redis.call('DEL', KEYS[1])
+redis.call('HSET', KEYS[1],
+    'leaseId', new_id,
+    'companyId', ARGV[5],
+    'creditTypeId', ARGV[6],
+    'grantedAmount', new_granted,
+    'localRemainingCredits', new_granted,
+    'expiresAt', ARGV[3])
+redis.call('PEXPIREAT', KEYS[1], new_expiry + grace)
+return 1
+`;
+
+/**
+ * Atomic check-and-decrement on `localRemainingCredits`. Returns the
+ * post-debit balance (as a string — a Lua number reply truncates to integer,
+ * which would corrupt fractional credit costs) on success; `false` (a nil
+ * reply) if there's no lease, the lease has expired, or there's insufficient
+ * remaining. Returning the balance saves the caller a follow-up read when it
+ * needs the pre-debit figure. The expiry guard compares against the Redis
+ * server clock (`now`, see `LEASE_NOW_MS`) so a reserve against an
+ * expired-but-not-yet-evicted row during the TTL grace window is rejected —
+ * the server treats an expired lease as released, so its balance is stale.
+ */
+const TRY_RESERVE_SCRIPT =
+    LEASE_NOW_MS +
+    `
+local raw = redis.call('HGET', KEYS[1], 'localRemainingCredits')
+if not raw then return false end
+local expiry = tonumber(redis.call('HGET', KEYS[1], 'expiresAt') or '0')
+if expiry <= now then return false end
+local remaining = tonumber(raw)
+local requested = tonumber(ARGV[1])
+if remaining < requested then return false end
+local new_remaining = remaining - requested
+redis.call('HSET', KEYS[1], 'localRemainingCredits', tostring(new_remaining))
+return tostring(new_remaining)
+`;
+
+/**
+ * Refund credits, clamped at `grantedAmount`. ARGV[2], when non-empty, pins
+ * the refund to a specific `leaseId`: if the slot now holds a different lease
+ * (the original expired and a successor was installed), the refund is dropped
+ * — the expired lease's unspent remainder was already returned to the company
+ * balance server-side, so crediting the successor would mint phantom credits.
+ */
+const REFUND_SCRIPT = `
+local raw_remaining = redis.call('HGET', KEYS[1], 'localRemainingCredits')
+if not raw_remaining then return 0 end
+local required_lease = ARGV[2]
+if required_lease and required_lease ~= '' then
+    local current_lease = redis.call('HGET', KEYS[1], 'leaseId')
+    if current_lease ~= required_lease then return 0 end
+end
+local remaining = tonumber(raw_remaining)
+local granted = tonumber(redis.call('HGET', KEYS[1], 'grantedAmount') or '0')
+local refund = tonumber(ARGV[1])
+local new_balance = remaining + refund
+if new_balance > granted then new_balance = granted end
+redis.call('HSET', KEYS[1], 'localRemainingCredits', tostring(new_balance))
+return 1
+`;
+
+/**
+ * Reconcile the lease to the server-authoritative grantedAmount total
+ * (ARGV[1]), crediting the difference to localRemainingCredits. The delta is
+ * computed HERE, atomically against the hash's current total — never by the
+ * caller from a pre-wire-call read: per-process single-flight doesn't cover
+ * sibling pods, so two pods extending the same shared lease concurrently
+ * would each apply a delta against the same stale read and mint phantom
+ * credits. Reconciling to the absolute total converges regardless of arrival
+ * order (a total a sibling already applied lands as `add <= 0`, a no-op).
+ * Expiry only ever moves forward, so an out-of-order apply can't shorten a
+ * lease a sibling just extended. ARGV[4], when non-empty, pins the extend to
+ * a specific `leaseId`: the server granted the extension to that lease, so if
+ * the slot now holds a successor (the original expired mid-extend and a
+ * racing acquire replaced it), the extend is dropped — crediting the
+ * successor would mint credits locally that the server attributes to the
+ * expired lease. Mirrors the pin on REFUND_SCRIPT.
+ */
+const EXTEND_SCRIPT = `
+local raw_granted = redis.call('HGET', KEYS[1], 'grantedAmount')
+if not raw_granted then return 0 end
+local required_lease = ARGV[4]
+if required_lease and required_lease ~= '' then
+    local current_lease = redis.call('HGET', KEYS[1], 'leaseId')
+    if current_lease ~= required_lease then return 0 end
+end
+local granted = tonumber(raw_granted)
+local target = tonumber(ARGV[1])
+local add = target - granted
+if add > 0 then
+    local remaining = tonumber(redis.call('HGET', KEYS[1], 'localRemainingCredits') or '0')
+    redis.call('HSET', KEYS[1],
+        'grantedAmount', tostring(target),
+        'localRemainingCredits', tostring(remaining + add))
+end
+local new_expiry = tonumber(ARGV[2])
+local grace = tonumber(ARGV[3])
+local current_expiry = tonumber(redis.call('HGET', KEYS[1], 'expiresAt') or '0')
+if new_expiry > current_expiry then
+    redis.call('HSET', KEYS[1], 'expiresAt', ARGV[2])
+    redis.call('PEXPIREAT', KEYS[1], new_expiry + grace)
+end
+return 1
+`;
+
+/**
+ * Redis-backed lease store. One hash per `(companyId, creditTypeId)` slot, with
+ * atomic mutations via single-key Lua scripts so it stays correct on both
+ * standalone and clustered Redis.
+ */
+export class RedisLeaseStore implements ILeaseStore {
+    private readonly client: RedisClient;
+    private readonly keyPrefix: string;
+    private readonly defaultLeaseDurationMs: number;
+
+    constructor(opts: {
+        client: RedisClient;
+        keyPrefix?: string;
+        /**
+         * Defensive fallback used by `extend()` when the caller doesn't supply
+         * `newExpiresAt`. The lease manager always passes one today, so this
+         * only matters for direct callers. Default `DEFAULT_LEASE_DURATION_MS`.
+         */
+        defaultLeaseDurationMs?: number;
+    }) {
+        this.client = opts.client;
+        this.keyPrefix = opts.keyPrefix ?? DEFAULT_KEY_PREFIX;
+        this.defaultLeaseDurationMs = opts.defaultLeaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+    }
+
+    /** Public so the reservation store can target the same lease hash for refunds. */
+    hashKey(companyId: string, creditTypeId: string): string {
+        return `${this.keyPrefix}${LEASE_KEY_NAMESPACE}${leaseKey(companyId, creditTypeId)}`;
+    }
+
+    async get(companyId: string, creditTypeId: string): Promise<LeaseEntry | undefined> {
+        const raw = await this.client.hGetAll(this.hashKey(companyId, creditTypeId));
+        if (!raw || !raw.leaseId) return undefined;
+        return decodeEntry(raw);
+    }
+
+    async replace(entry: Omit<LeaseEntry, "localRemainingCredits">): Promise<boolean> {
+        const result = await this.client.eval(REPLACE_SCRIPT, {
+            keys: [this.hashKey(entry.companyId, entry.creditTypeId)],
+            // No client clock here — the script reads `now` from the Redis
+            // server via TIME (see LEASE_NOW_MS) so all pods agree on expiry.
+            arguments: [
+                entry.leaseId,
+                String(entry.grantedAmount),
+                String(entry.expiresAt.getTime()),
+                String(LEASE_TTL_GRACE_MS),
+                entry.companyId,
+                entry.creditTypeId,
+            ],
+        });
+        return Number(result) === 1;
+    }
+
+    async extend(
+        companyId: string,
+        creditTypeId: string,
+        grantedAmount: number,
+        newExpiresAt?: Date,
+        leaseId?: string,
+    ): Promise<void> {
+        const expiry = (newExpiresAt ?? new Date(Date.now() + this.defaultLeaseDurationMs)).getTime();
+        await this.client.eval(EXTEND_SCRIPT, {
+            keys: [this.hashKey(companyId, creditTypeId)],
+            // grantedAmount is the server-authoritative TOTAL; the script
+            // computes the credit delta atomically against the stored total.
+            // Empty string disables the lease pin (Lua has no nil ARGV).
+            arguments: [String(grantedAmount), String(expiry), String(LEASE_TTL_GRACE_MS), leaseId ?? ""],
+        });
+    }
+
+    async drop(companyId: string, creditTypeId: string): Promise<void> {
+        // A plain single-key delete — no secondary index to keep in sync.
+        await this.client.del(this.hashKey(companyId, creditTypeId));
+    }
+
+    async tryReserve(companyId: string, creditTypeId: string, credits: number): Promise<number | null> {
+        // Reject non-finite/negative debits before they reach the script:
+        // `String(NaN)` parses back to `nan` in Lua (strtod), slips through the
+        // `<` comparison, and would poison the SHARED balance for every pod.
+        if (!Number.isFinite(credits) || credits < 0) return null;
+        const result = await this.client.eval(TRY_RESERVE_SCRIPT, {
+            keys: [this.hashKey(companyId, creditTypeId)],
+            // Only the requested amount — `now` comes from the Redis server clock.
+            arguments: [String(credits)],
+        });
+        // nil reply (could not reserve) surfaces as null; success is the
+        // post-debit balance as a string.
+        if (result === null || result === undefined) return null;
+        return Number(result);
+    }
+
+    async refund(companyId: string, creditTypeId: string, credits: number, leaseId?: string): Promise<void> {
+        if (credits <= 0) return;
+        await this.client.eval(REFUND_SCRIPT, {
+            keys: [this.hashKey(companyId, creditTypeId)],
+            // Empty string disables the lease pin (Lua has no nil ARGV).
+            arguments: [String(credits), leaseId ?? ""],
+        });
+    }
+}
+
+function decodeEntry(raw: Record<string, string>): LeaseEntry {
+    return {
+        leaseId: raw.leaseId,
+        companyId: raw.companyId,
+        creditTypeId: raw.creditTypeId,
+        grantedAmount: Number(raw.grantedAmount ?? "0"),
+        localRemainingCredits: Number(raw.localRemainingCredits ?? "0"),
+        expiresAt: new Date(Number(raw.expiresAt ?? "0")),
+    };
+}

--- a/src/credits/redis-reservation-store.ts
+++ b/src/credits/redis-reservation-store.ts
@@ -1,0 +1,297 @@
+import type { RedisClient } from "../cache/redis";
+
+import type { ILeaseStore } from "./lease-store";
+import type { IReservationStore } from "./reservation-store";
+import type { Reservation } from "./types";
+
+const DEFAULT_KEY_PREFIX = "schematic:";
+const RES_KEY_NAMESPACE = "credit-reservation:";
+// Sorted set scoring open reservations by `expiresAt` so the sweeper can pop
+// expired entries in O(log n). Members encode the full (company, credit, id)
+// tuple — see `encodeMember` for why.
+const RES_INDEX_KEY = "credit-reservations:byExpiry";
+// Per-(company, credit) index of open reservations, stored as a single hash
+// of `reservationId -> creditsReserved`. `reservedCredits` then reads the whole
+// tenant's holds with ONE `HGETALL` (single key, Cluster-safe) and sums the
+// values, instead of fanning out a per-reservation read. The hash also *is* the
+// source of truth for the sum: a field exists iff its reservation is open and
+// unrefunded (consume removes the field and refunds in the same call), so the
+// sum stays exact without cross-checking the reservation hashes.
+const RES_BYCREDIT_NAMESPACE = "credit-reservations:byCredit:";
+// Buffer past `expiresAt` before Redis auto-evicts the row, so the sweeper
+// has a window to refund.
+const RES_TTL_GRACE_MS = 30_000;
+
+/**
+ * Atomic claim: read the reservation hash and delete it in one step, returning
+ * its fields (or `nil` if it was already gone). Touches a single key, so it's
+ * safe under Redis Cluster. The atomic read-then-delete is what makes
+ * `consume` exactly-once: of two racing callers (a normal Track and a sweeper,
+ * say) only one gets the fields back and proceeds to refund — the other sees
+ * `nil`. The refund to the lease hash is a separate single-key op; a crash in
+ * the gap leaves the unspent slice held on the lease until the lease itself
+ * expires, never double-refunded.
+ */
+const CLAIM_SCRIPT = `
+local raw = redis.call('HGETALL', KEYS[1])
+if #raw == 0 then return nil end
+redis.call('DEL', KEYS[1])
+return raw
+`;
+
+// `byExpiry` zset members encode the (company, credit, id) tuple so the sweeper
+// can clean the per-tenant `byCredit` hash even after the reservation hash has
+// TTL-evicted (at which point CLAIM returns nil and can't report company/credit);
+// otherwise the orphaned field would permanently inflate `reservedCredits`.
+// The delimiter `|` is absent from Schematic ids and the UUID reservation id.
+function encodeMember(r: { companyId: string; creditTypeId: string; id: string }): string {
+    return `${r.companyId}|${r.creditTypeId}|${r.id}`;
+}
+
+// Returns undefined for a member that doesn't parse (shouldn't happen — only
+// `add` writes members); the sweeper drops such a member so it can't wedge
+// the sweep loop.
+function decodeMember(member: string): { companyId: string; creditTypeId: string; id: string } | undefined {
+    const parts = member.split("|");
+    if (parts.length !== 3) return undefined;
+    return { companyId: parts[0], creditTypeId: parts[1], id: parts[2] };
+}
+
+// Page size for the sweeper's ZRANGEBYSCORE. Without a LIMIT, a backlog of
+// expired holds (e.g. after a Redis outage or a long pod pause) would come
+// back as one giant reply on every pod's next tick; paging bounds the reply
+// while the per-member zRem keeps `offset: 0` advancing through the backlog.
+const SWEEP_BATCH_SIZE = 256;
+// Upper bound on pages per tick — keeps a single sweep's work bounded and
+// guards against an endless loop if zRem persistently fails (the member would
+// otherwise be re-read forever). Anything left over is picked up next tick.
+const MAX_SWEEP_BATCHES = 16;
+
+/**
+ * Redis-backed reservation table. Each reservation is a hash, indexed by
+ * `expiresAt` in a sorted set so the sweeper can pop expired entries in
+ * O(log n), and by `(company, credit)` so the balance display can sum a
+ * tenant's open holds. All mutations use single-key operations (or single-key
+ * Lua), so the store is correct on standalone and clustered Redis alike — the
+ * unspent-slice refund is delegated to the lease store rather than reaching
+ * across to the lease hash inside a multi-key script.
+ */
+export class RedisReservationStore implements IReservationStore {
+    private readonly client: RedisClient;
+    private readonly leaseStore: ILeaseStore;
+    private readonly sweepIntervalMs: number;
+    private readonly keyPrefix: string;
+    private sweepInterval: NodeJS.Timeout | null = null;
+    private stopped = false;
+
+    constructor(opts: {
+        client: RedisClient;
+        leaseStore: ILeaseStore;
+        sweepIntervalMs?: number;
+        keyPrefix?: string;
+    }) {
+        this.client = opts.client;
+        this.leaseStore = opts.leaseStore;
+        this.sweepIntervalMs = opts.sweepIntervalMs ?? 1000;
+        this.keyPrefix = opts.keyPrefix ?? DEFAULT_KEY_PREFIX;
+    }
+
+    private hashKey(id: string): string {
+        return `${this.keyPrefix}${RES_KEY_NAMESPACE}${id}`;
+    }
+
+    private indexKey(): string {
+        return `${this.keyPrefix}${RES_INDEX_KEY}`;
+    }
+
+    private byCreditKey(companyId: string, creditTypeId: string): string {
+        return `${this.keyPrefix}${RES_BYCREDIT_NAMESPACE}${companyId}:${creditTypeId}`;
+    }
+
+    async add(reservation: Reservation): Promise<void> {
+        const expiresMs = reservation.expiresAt.getTime();
+        const hashKey = this.hashKey(reservation.id);
+        // Write the hash first so the reservation exists before anything
+        // references it. These are independent single-key ops rather than one
+        // multi-key script: a partial failure at worst leaves an un-indexed
+        // reservation that the TTL reaps (its slice reclaimed when the lease
+        // expires), never a double-spend.
+        await this.client.hSet(hashKey, {
+            id: reservation.id,
+            leaseId: reservation.leaseId,
+            companyId: reservation.companyId,
+            creditTypeId: reservation.creditTypeId,
+            eventSubtype: reservation.eventSubtype,
+            quantityReserved: String(reservation.quantityReserved),
+            creditsReserved: String(reservation.creditsReserved),
+            consumptionRate: String(reservation.consumptionRate),
+            expiresAt: String(expiresMs),
+            evalCtx: JSON.stringify(reservation.evalCtx),
+        });
+        // The TTL and the two indexes (expiry zset for the sweeper, per-tenant
+        // hash for `reservedCredits`) only depend on the hash existing — not on
+        // each other — so they go out concurrently: one round-trip wave instead
+        // of three. This sits on every allowed check, so the latency matters.
+        await Promise.all([
+            this.client.pExpireAt(hashKey, expiresMs + RES_TTL_GRACE_MS),
+            this.client.zAdd(this.indexKey(), { score: expiresMs, value: encodeMember(reservation) }),
+            this.client.hSet(
+                this.byCreditKey(reservation.companyId, reservation.creditTypeId),
+                reservation.id,
+                String(reservation.creditsReserved),
+            ),
+        ]);
+    }
+
+    async get(id: string): Promise<Reservation | undefined> {
+        const raw = await this.client.hGetAll(this.hashKey(id));
+        if (!raw || !raw.id) return undefined;
+        return decodeReservation(raw);
+    }
+
+    /**
+     * Sum open reservations for a (company, credit) with a single `HGETALL` on
+     * the per-tenant index hash — one round trip, one key (Cluster-safe), no
+     * per-reservation fan-out. The hash values are the authoritative
+     * `creditsReserved` figures; a field is present iff its reservation is open
+     * and unrefunded (consume removes the field and refunds in the same call),
+     * so summing them is exact. Display-path call, not a hot path.
+     */
+    async reservedCredits(companyId: string, creditTypeId: string): Promise<number> {
+        const byCredit = await this.client.hGetAll(this.byCreditKey(companyId, creditTypeId)).catch(() => ({}));
+        let total = 0;
+        for (const value of Object.values(byCredit)) {
+            total += Number(value) || 0;
+        }
+        return total;
+    }
+
+    async consume(id: string, creditsConsumed: number): Promise<number | null> {
+        // Atomically claim (read + delete) the reservation hash. Only one caller
+        // wins; a duplicate/racing consume gets nil and returns null.
+        const claimed = await this.client.eval(CLAIM_SCRIPT, {
+            keys: [this.hashKey(id)],
+            arguments: [],
+        });
+        const raw = decodeRawArray(claimed);
+        if (!raw || !raw.id) return null;
+
+        const companyId = raw.companyId;
+        const creditTypeId = raw.creditTypeId;
+        const reserved = Number(raw.creditsReserved) || 0;
+
+        // Index cleanup — single-key ops. Drop the credits from the per-tenant
+        // hash BEFORE the refund below so the lease (localRemaining + this hash)
+        // never transiently double-counts the slice: while it sits on the hash
+        // it's "reserved", and the refund moves it back to localRemaining.
+        await this.client.zRem(this.indexKey(), encodeMember({ companyId, creditTypeId, id })).catch(() => {});
+        await this.client.hDel(this.byCreditKey(companyId, creditTypeId), id).catch(() => {});
+
+        let consumed = creditsConsumed;
+        if (consumed < 0) consumed = 0;
+        if (consumed > reserved) consumed = reserved;
+        const refund = reserved - consumed;
+        if (refund > 0) {
+            // Delegate the clamped refund to the lease store, which owns the
+            // lease hash. Keeps the cross-key write out of a single Lua script.
+            // Pinned to the reservation's leaseId so a hold carved out of an
+            // expired lease can't inflate a successor lease's balance.
+            await this.leaseStore.refund(companyId, creditTypeId, refund, raw.leaseId);
+        }
+        return consumed;
+    }
+
+    startSweep(): void {
+        if (this.sweepInterval || this.stopped) return;
+        this.sweepInterval = setInterval(() => {
+            this.sweepExpired().catch(() => {
+                // Swallow so the timer keeps running.
+            });
+        }, this.sweepIntervalMs);
+        if (this.sweepInterval.unref) this.sweepInterval.unref();
+    }
+
+    async sweepExpired(now: Date = new Date()): Promise<number> {
+        const cutoff = now.getTime();
+        let swept = 0;
+        // Page through expired members (encoded `company|credit|id`, scored by
+        // expiresAt) rather than fetching them all at once. Each processed
+        // member is zRem'd below, so re-reading at `offset: 0` advances through
+        // the backlog; MAX_SWEEP_BATCHES bounds the work per tick.
+        for (let batch = 0; batch < MAX_SWEEP_BATCHES; batch++) {
+            const expired = await this.client.zRangeByScore(this.indexKey(), 0, cutoff, {
+                LIMIT: { offset: 0, count: SWEEP_BATCH_SIZE },
+            });
+            if (expired.length === 0) break;
+            for (const member of expired) {
+                const decoded = decodeMember(member);
+                if (!decoded) {
+                    // Unparseable member (nothing but `add` writes these, so
+                    // this is belt-and-braces) — drop it so it can't wedge the
+                    // sweeper.
+                    await this.client.zRem(this.indexKey(), member).catch(() => {});
+                    continue;
+                }
+                const refunded = await this.consume(decoded.id, 0);
+                // Always drop the member we read. On the success path `consume`
+                // already removed it (so this is an idempotent no-op); it also
+                // covers the hash-evicted path below.
+                await this.client.zRem(this.indexKey(), member).catch(() => {});
+                if (refunded !== null) {
+                    swept++;
+                    continue;
+                }
+                // `consume` found no reservation hash. Either a racing track already
+                // consumed it (and reconciled the `byCredit` field — the hDel below is
+                // then a no-op), or the hash TTL-evicted before the sweeper reached it,
+                // orphaning the `byCredit` field. Reconcile it so `reservedCredits`
+                // can't keep summing an evicted hold. We do NOT refund the unspent
+                // slice here: without the hash, CLAIM can't arbitrate exactly-once
+                // across racing sweepers, so the slice is reclaimed when the lease
+                // itself expires server-side instead.
+                await this.client
+                    .hDel(this.byCreditKey(decoded.companyId, decoded.creditTypeId), decoded.id)
+                    .catch(() => {});
+            }
+            if (expired.length < SWEEP_BATCH_SIZE) break;
+        }
+        return swept;
+    }
+
+    stop(): void {
+        this.stopped = true;
+        if (this.sweepInterval) {
+            clearInterval(this.sweepInterval);
+            this.sweepInterval = null;
+        }
+    }
+
+    async size(): Promise<number> {
+        return this.client.zCard(this.indexKey()).catch(() => 0);
+    }
+}
+
+/** Decode a flat `[field, value, field, value, ...]` HGETALL array (as CLAIM_SCRIPT returns). */
+function decodeRawArray(raw: unknown): Record<string, string> | undefined {
+    if (!Array.isArray(raw) || raw.length === 0) return undefined;
+    const out: Record<string, string> = {};
+    for (let i = 0; i + 1 < raw.length; i += 2) {
+        out[String(raw[i])] = String(raw[i + 1]);
+    }
+    return out;
+}
+
+function decodeReservation(raw: Record<string, string>): Reservation {
+    return {
+        id: raw.id,
+        leaseId: raw.leaseId,
+        companyId: raw.companyId,
+        creditTypeId: raw.creditTypeId,
+        eventSubtype: raw.eventSubtype,
+        quantityReserved: Number(raw.quantityReserved),
+        creditsReserved: Number(raw.creditsReserved),
+        consumptionRate: Number(raw.consumptionRate),
+        expiresAt: new Date(Number(raw.expiresAt)),
+        evalCtx: raw.evalCtx ? JSON.parse(raw.evalCtx) : {},
+    };
+}

--- a/src/credits/reservation-store.ts
+++ b/src/credits/reservation-store.ts
@@ -1,0 +1,134 @@
+import type { Reservation } from "./types";
+import type { ILeaseStore } from "./lease-store";
+
+/** Backing-store contract for the reservation table. */
+export interface IReservationStore {
+    add(reservation: Reservation): Promise<void> | void;
+    get(id: string): Promise<Reservation | undefined> | Reservation | undefined;
+    consume(id: string, creditsConsumed: number): Promise<number | null>;
+    /**
+     * Sum of `creditsReserved` across open reservations for a (company, credit).
+     * These credits are carved out of the lease's `localRemainingCredits` but
+     * aren't spent yet, so a balance display can add them back to ignore
+     * in-flight holds.
+     */
+    reservedCredits(companyId: string, creditTypeId: string): Promise<number> | number;
+    startSweep(): void;
+    sweepExpired(now?: Date): Promise<number>;
+    stop(): void;
+    size(): Promise<number> | number;
+}
+
+/**
+ * In-memory reservation table, paired with a sweep loop that returns expired
+ * reservations to their underlying lease.
+ *
+ * For cross-pod deployments, swap this for `RedisReservationStore` — both
+ * implement `IReservationStore`.
+ */
+export class ReservationStore implements IReservationStore {
+    private reservations = new Map<string, Reservation>();
+    private sweepInterval: NodeJS.Timeout | null = null;
+    private stopped = false;
+
+    constructor(
+        private readonly leaseStore: ILeaseStore,
+        private readonly sweepIntervalMs: number = 1000,
+    ) {}
+
+    /** Register a new reservation. Idempotent on `id`. */
+    add(reservation: Reservation): void {
+        this.reservations.set(reservation.id, reservation);
+    }
+
+    /** Look up a reservation by ID. */
+    get(id: string): Reservation | undefined {
+        return this.reservations.get(id);
+    }
+
+    /**
+     * Sum open reservations for a (company, credit). Counts every reservation
+     * still in the table: its credits stay carved out of the lease's
+     * `localRemainingCredits` until `consume`/`sweepExpired` removes it and
+     * refunds the unspent remainder in the same step, so summing by presence
+     * keeps `localRemainingCredits + reservedCredits` exact.
+     */
+    reservedCredits(companyId: string, creditTypeId: string): number {
+        let total = 0;
+        for (const reservation of this.reservations.values()) {
+            if (reservation.companyId === companyId && reservation.creditTypeId === creditTypeId) {
+                total += reservation.creditsReserved;
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Consume a reservation — removes it from the table and refunds
+     * `creditsReserved - creditsConsumed` back to the underlying lease.
+     * Returns the credits actually consumed (clamped to `creditsReserved`)
+     * or `null` if the reservation is missing/already consumed.
+     */
+    async consume(id: string, creditsConsumed: number): Promise<number | null> {
+        const reservation = this.reservations.get(id);
+        if (!reservation) return null;
+        this.reservations.delete(id);
+
+        const actual = Math.max(0, Math.min(creditsConsumed, reservation.creditsReserved));
+        const refund = reservation.creditsReserved - actual;
+        if (refund > 0) {
+            // Pinned to the originating lease: if that lease has expired and a
+            // successor occupies the slot, the refund is dropped (the expired
+            // lease's remainder was already returned server-side).
+            await this.leaseStore.refund(reservation.companyId, reservation.creditTypeId, refund, reservation.leaseId);
+        }
+        return actual;
+    }
+
+    /** Start the background sweep loop. Safe to call repeatedly. */
+    startSweep(): void {
+        if (this.sweepInterval || this.stopped) return;
+        this.sweepInterval = setInterval(() => {
+            this.sweepExpired().catch(() => {
+                // sweepExpired only throws on programmer error; swallow so the
+                // timer keeps running.
+            });
+        }, this.sweepIntervalMs);
+        if (this.sweepInterval.unref) this.sweepInterval.unref();
+    }
+
+    /**
+     * Scan for expired reservations, remove them, and refund their credits to
+     * the lease.
+     */
+    async sweepExpired(now: Date = new Date()): Promise<number> {
+        let swept = 0;
+        for (const [id, reservation] of this.reservations) {
+            if (reservation.expiresAt.getTime() <= now.getTime()) {
+                this.reservations.delete(id);
+                await this.leaseStore.refund(
+                    reservation.companyId,
+                    reservation.creditTypeId,
+                    reservation.creditsReserved,
+                    reservation.leaseId,
+                );
+                swept++;
+            }
+        }
+        return swept;
+    }
+
+    /** Stop the sweep loop. */
+    stop(): void {
+        this.stopped = true;
+        if (this.sweepInterval) {
+            clearInterval(this.sweepInterval);
+            this.sweepInterval = null;
+        }
+    }
+
+    /** Test/debug: current reservation count. */
+    size(): number {
+        return this.reservations.size;
+    }
+}

--- a/src/credits/track.ts
+++ b/src/credits/track.ts
@@ -1,0 +1,84 @@
+import * as api from "../api";
+
+import type { IReservationStore } from "./reservation-store";
+import type { Reservation, TrackWithReservationOptions } from "./types";
+
+/** Outcome of consuming a reservation and building its Track event. */
+export interface ReservationConsumeResult {
+    /** The Track event to emit. Always carries the `leaseId`. */
+    track: api.EventBodyTrack;
+    /**
+     * `true` when the reservation was still live and `consume` debited/refunded
+     * the local lease in this call. `false` when the reservation was already
+     * gone from the store (swept after its TTL, or already consumed): the local
+     * lease balance was *not* touched here, and the returned `track` is a
+     * recovery event so the server still bills the actual usage. The caller is
+     * responsible for de-duping recovery emits (see `trackWithReservation`).
+     */
+    settledLocally: boolean;
+}
+
+/**
+ * Build the `EventBodyTrack` payload for a Track event that consumes a
+ * reservation, and consume the reservation against the lease (refunding the
+ * unused slice locally).
+ *
+ * The Track is built from the caller-held `reservation` handle, so it can be
+ * emitted even when the reservation has already been swept out of the store —
+ * the server is the source of truth for actual consumption. When the lease is
+ * still live server-side the `leaseId` routes the spend through its sub-ledger;
+ * when the server lease has itself expired/released, the server falls through
+ * to a direct grant decrement. Either way the usage is billed, so a hold that
+ * outlives its (client-side) reservation TTL is no longer dropped on the floor.
+ *
+ * On the recovery path (`settledLocally: false`) the sweeper already refunded
+ * the full hold and nothing re-debits the consumed slice, so the local lease
+ * reads high until rollover — hence `reservationTTL` should exceed the longest
+ * expected work duration (see `CreditLeaseConfig.defaultReservationTTL`).
+ */
+export async function consumeReservationAndBuildEvent(
+    reservations: IReservationStore,
+    reservation: Reservation,
+    actualQuantity: number,
+    options?: TrackWithReservationOptions,
+): Promise<ReservationConsumeResult> {
+    const credits = actualQuantity * reservation.consumptionRate;
+    const consumed = await reservations.consume(reservation.id, credits);
+    return {
+        track: buildReservationTrackEvent(reservation, actualQuantity, options),
+        settledLocally: consumed !== null,
+    };
+}
+
+/**
+ * Build the Track event for a reservation purely from the caller-held handle —
+ * no store access. Split out so `trackWithReservation` can still emit the
+ * billing event when the local settle (`consume`) fails on an unreachable
+ * store: the server is the source of truth for actual consumption, so the
+ * usage must be reported regardless of local bookkeeping.
+ */
+export function buildReservationTrackEvent(
+    reservation: Reservation,
+    actualQuantity: number,
+    options?: TrackWithReservationOptions,
+): api.EventBodyTrack {
+    const body: api.EventBodyTrack = {
+        event: reservation.eventSubtype,
+        quantity: actualQuantity,
+        // Routes the server-side credit consumption through the lease's
+        // sub-ledger instead of decrementing the grant again (which was
+        // already pre-debited at acquire/extend). Without this the grant
+        // double-debits and eventually starves redemptions mid-session.
+        leaseId: reservation.leaseId,
+    };
+    if (reservation.evalCtx.company) {
+        body.company = reservation.evalCtx.company;
+    }
+    if (reservation.evalCtx.user) {
+        body.user = reservation.evalCtx.user;
+    }
+    if (options?.traits) {
+        body.traits = options.traits;
+    }
+    return body;
+}

--- a/src/credits/types.ts
+++ b/src/credits/types.ts
@@ -1,0 +1,193 @@
+import type * as api from "../api";
+import type { RedisClient } from "../cache/redis";
+
+/**
+ * Behavior when a lease cannot be acquired or reserved against (API error,
+ * lease/reservation store unreachable, insufficient balance).
+ * - `fail-open`: err on the side of assuming the credits are there — the rules
+ *   engine still evaluates the flag (plan targeting, overrides, and all
+ *   non-credit conditions apply) with the credit balance substituted to an
+ *   effectively unlimited value, so only the credit gate is bypassed. No
+ *   reservation is issued.
+ * - `fail-closed`: `check()` returns `{ allowed: false }` so the caller blocks the action
+ */
+export type OnAcquireFailure = "fail-open" | "fail-closed";
+
+// Single source of truth for defaults consumed by `CreditLeaseManager` and
+// `SchematicClient`. Re-exported so the values referenced in the doc strings
+// below stay accurate even if a consumer overrides only a subset of fields.
+export const DEFAULT_LEASE_DURATION_MS: number = 5 * 60 * 1000;
+export const DEFAULT_RESERVATION_TTL_MS: number = 60 * 1000;
+export const DEFAULT_LEASE_SIZE: number = 10_000;
+export const DEFAULT_LOW_WATER_MARK: number = 0.25;
+export const DEFAULT_SWEEP_INTERVAL_MS: number = 1000;
+// How long `prewarm()` is willing to wait for a freshly-identified company to
+// surface in the datastream cache before giving up. Long enough to cover the
+// buffer-flush → server-ingest → datastream-push round-trip for a new
+// company; short enough that a misconfigured caller doesn't hang.
+export const DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS: number = 5000;
+export const DEFAULT_PREWARM_POLL_INTERVAL_MS: number = 100;
+
+/**
+ * Configuration block enabling client-side lease + reservation behavior on
+ * `client.check` / `client.trackWithReservation`. Omit to keep the SDK
+ * lease-unaware (`check` falls back to a plain flag check).
+ */
+export interface CreditLeaseConfig {
+    /** Default lease duration in milliseconds. Default `DEFAULT_LEASE_DURATION_MS` (5 minutes). */
+    defaultLeaseDuration?: number;
+    /**
+     * Default reservation TTL in milliseconds. Default `DEFAULT_RESERVATION_TTL_MS`
+     * (60 seconds). Size this above the longest expected gap between `check()`
+     * and `trackWithReservation()`: a settle arriving after the TTL still bills
+     * the server but doesn't re-debit the local lease (its hold was already
+     * swept back), so the local balance reads high until the lease rolls over.
+     */
+    defaultReservationTTL?: number;
+    /** Default lease size (credit amount requested). Default `DEFAULT_LEASE_SIZE` (10000). */
+    defaultLeaseSize?: number;
+    /**
+     * Fraction of remaining lease balance below which the SDK kicks off a
+     * background extend. Default `DEFAULT_LOW_WATER_MARK` (0.25).
+     */
+    lowWaterMark?: number;
+    /** Sweep interval (ms) for expired reservations. Default `DEFAULT_SWEEP_INTERVAL_MS` (1000). */
+    sweepIntervalMs?: number;
+    /**
+     * Max time `prewarm()` will wait for a freshly-identified company to
+     * surface in the datastream cache when only secondary keys are passed.
+     * Set to 0 to skip waiting entirely (prewarm bails immediately if the
+     * company isn't already cached). Default `DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS`
+     * (5000ms).
+     */
+    prewarmResolveTimeoutMs?: number;
+    /**
+     * Pre-connected Redis client for lease + reservation state. Optional: when
+     * omitted, the SDK reuses the DataStream cache's Redis client
+     * (`dataStream.redisClient`) if one is configured, so an existing Redis
+     * setup backs leases automatically. Set this only to point lease state at a
+     * *different* Redis than the DataStream cache.
+     *
+     * When neither this nor `dataStream.redisClient` is configured, the SDK
+     * falls back to per-process in-memory stores — single-pod only, since
+     * cross-pod gating is lost (a warning is logged). With a Redis client
+     * present, the Lua-driven `tryReserve` / `consume` paths give atomic
+     * cross-pod gating.
+     */
+    redisClient?: RedisClient;
+    /**
+     * Optional Redis key prefix. Falls back to `dataStream.redisKeyPrefix` when
+     * unset, then to `schematic:`.
+     */
+    redisKeyPrefix?: string;
+    /** Per-credit-type overrides (keyed by credit type ID). */
+    overrides?: Record<
+        string,
+        Partial<Omit<CreditLeaseConfig, "overrides" | "sweepIntervalMs" | "redisClient" | "redisKeyPrefix">>
+    >;
+}
+
+/** Resolved config for a single credit type after applying defaults + overrides. */
+export interface ResolvedLeaseConfig {
+    leaseDuration: number;
+    reservationTTL: number;
+    leaseSize: number;
+    lowWaterMark: number;
+}
+
+/** Handle returned by `client.check` when a reservation is issued. Pass to `client.trackWithReservation`. */
+export interface Reservation {
+    /** Opaque reservation ID. */
+    id: string;
+    /** Underlying lease ID this reservation draws from. */
+    leaseId: string;
+    /** Company that owns the lease. */
+    companyId: string;
+    /** Credit type the reservation reserves against. */
+    creditTypeId: string;
+    /** Event subtype to record on the Track event when consumed. */
+    eventSubtype: string;
+    /** Quantity (in event units) the caller declared upfront. */
+    quantityReserved: number;
+    /** Credits reserved = `quantityReserved * consumptionRate`. */
+    creditsReserved: number;
+    /** Consumption rate at the time the reservation was issued. */
+    consumptionRate: number;
+    /** When the reservation expires and gets swept back to the lease. */
+    expiresAt: Date;
+    /**
+     * Evaluation context used to issue this reservation. Threaded into the
+     * Track event in `trackWithReservation` so the server can attribute usage
+     * to the same company/user.
+     */
+    evalCtx: api.CheckFlagRequestBody;
+}
+
+/** Options accepted by `client.check`. */
+export interface CheckOptions {
+    /**
+     * Quantity (in event units) to gate the check on — the check reserves
+     * `usage × consumption_rate` credits from the lease. A check issues at
+     * most ONE reservation, against a single event subtype.
+     */
+    usage?: number;
+    /**
+     * Event subtype the `usage` applies to (e.g. `"inference_tokens"`).
+     * Disambiguates which credit condition to gate on when the flag meters
+     * more than one event. Optional when the flag's credit condition is
+     * unambiguous.
+     */
+    eventSubtype?: string;
+    /**
+     * What to do when a lease cannot be acquired (API error, store
+     * unreachable, insufficient remote balance). Default: `fail-closed`
+     * (`allowed = false`, no reservation) — deny when the gate can't gate.
+     * Override to `fail-open` for trusted/known customers where letting
+     * traffic through is preferable to a denial; the flag's rules are still
+     * evaluated with an assumed-sufficient credit balance, so only the credit
+     * gate is bypassed (see `OnAcquireFailure`).
+     */
+    onAcquireFailure?: OnAcquireFailure;
+    /** Default value to return on error. */
+    defaultValue?: boolean | (() => boolean);
+    /** Custom timeout for API calls within this check (ms). */
+    timeoutMs?: number;
+}
+
+/** Result of `client.check`. */
+export interface CheckResult {
+    /** Whether the caller is permitted to proceed. */
+    allowed: boolean;
+    /** Boolean flag value (`allowed` mirrors this in non-lease paths). */
+    value: boolean;
+    /** Reservation handle when a lease-bearing check passed. */
+    reservation?: Reservation;
+    /** Human-readable reason (from the rules engine or the SDK). */
+    reason: string;
+    /**
+     * Entitlement payload from the check.
+     *
+     * NOTE: `entitlement.creditRemaining` (and `creditTotal` / `creditUsed`) is
+     * NOT lease-aware and must not be used as a user-facing balance when credit
+     * leases are enabled. The WASM derives those fields from the company's
+     * server `creditBalances`, which a lease distorts: a plain `checkFlag` sees
+     * the balance net of the whole lease tranche (reads low/~0), and a
+     * lease-bearing `check()` sees the substituted *tranche-local* balance, not
+     * the company total. For any "credits remaining" display use
+     * `client.getCreditBalance(...).settled` (`B − spent`), which speaks the
+     * server's `remaining`/`reserved`/`settled` vocabulary.
+     */
+    entitlement?: api.RulesengineFeatureEntitlement;
+    /** Flag key checked. */
+    flagKey: string;
+    /** Flag ID if known. */
+    flagId?: string;
+    /** Optional error string (populated when the SDK fell back to a default). */
+    err?: string;
+}
+
+/** Extras accepted by `trackWithReservation`. */
+export interface TrackWithReservationOptions {
+    /** Optional traits to attach to the emitted Track event. */
+    traits?: Record<string, unknown>;
+}

--- a/src/datastream/datastream-client.ts
+++ b/src/datastream/datastream-client.ts
@@ -1,7 +1,9 @@
 import * as Schematic from '../api/types';
+import { SchematicEnvironment } from '../environments';
 import type { DatastreamWSClient } from './websocket-client';
 import { DataStreamResp, DataStreamReq, DataStreamError, EntityType, MessageType } from './types';
 import { RulesEngineClient } from '../rules-engine';
+import type { CheckFlagOptions } from '../wrapper';
 import { Logger } from '../logger';
 import { LazyEmitter } from './emitter';
 import { partialCompany, partialUser, deepCopyCompany as deepCopyCompanyFn } from './merge';
@@ -18,7 +20,11 @@ import { RedisCacheProvider, type RedisClient } from '../cache/redis';
 export interface DataStreamClientOptions {
   /** Schematic API key for authentication */
   apiKey: string;
-  /** Base URL for the API (will be converted to WebSocket URL) */
+  /**
+   * Base URL for the API, converted to its WebSocket counterpart (e.g.
+   * https://api.schematichq.com -> wss://datastream.schematichq.com).
+   * Defaults to the standard Schematic API environment.
+   */
   baseURL?: string;
   /** Logger for debug/info/error messages */
   logger: Logger;
@@ -61,7 +67,7 @@ const MAX_CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days (matches Go maxCacheT
  */
 export class DataStreamClient extends LazyEmitter {
   private readonly apiKey: string;
-  private readonly baseURL?: string;
+  private readonly baseURL: string;
   private readonly logger: Logger;
   private readonly cacheTTL: number;
 
@@ -97,7 +103,9 @@ export class DataStreamClient extends LazyEmitter {
     super();
 
     this.apiKey = options.apiKey;
-    this.baseURL = options.baseURL;
+    // Default to the standard API environment, mirroring the REST client —
+    // the WS layer maps api.* hosts to their datastream.* counterpart.
+    this.baseURL = options.baseURL ?? SchematicEnvironment.Default;
     this.logger = options.logger;
     this.cacheTTL = options.cacheTTL ?? DEFAULT_TTL;
 
@@ -217,10 +225,6 @@ export class DataStreamClient extends LazyEmitter {
         this.startReplicatorHealthCheck();
       }
       return;
-    }
-
-    if (!this.baseURL) {
-      throw new Error('BaseURL is required when not in replicator mode');
     }
 
     this.logger.info('Starting DataStream client');
@@ -475,7 +479,8 @@ export class DataStreamClient extends LazyEmitter {
    */
   public async checkFlag(
     evalCtx: { company?: Record<string, string>; user?: Record<string, string> },
-    flagKey: string
+    flagKey: string,
+    options?: CheckFlagOptions
   ): Promise<Schematic.RulesengineCheckFlagResult> {
     // Get flag first - return error if not found
     const flag = await this.getFlag(flagKey);
@@ -503,13 +508,13 @@ export class DataStreamClient extends LazyEmitter {
     if (this.replicatorMode) {
       // In replicator mode, if we don't have all cached data, evaluate with null values instead of fetching
       // The external replicator should have populated the cache with all necessary data
-      return this.evaluateFlag(flag, cachedCompany, cachedUser);
+      return this.evaluateFlag(flag, cachedCompany, cachedUser, options);
     }
 
     // Non-replicator mode: if we have all cached data we need, use it
     if ((!needsCompany || cachedCompany) && (!needsUser || cachedUser)) {
       this.logger.debug(`All required resources found in cache for flag ${flagKey} evaluation`);
-      return this.evaluateFlag(flag, cachedCompany, cachedUser);
+      return this.evaluateFlag(flag, cachedCompany, cachedUser, options);
     }
 
     // Check if we're connected to datastream for live fetching
@@ -529,7 +534,30 @@ export class DataStreamClient extends LazyEmitter {
     const [company, user] = await Promise.all([companyPromise, userPromise]);
 
     // Evaluate against the rules engine
-    return this.evaluateFlag(flag, company, user);
+    return this.evaluateFlag(flag, company, user, options);
+  }
+
+  /**
+   * Public accessor for the cached company snapshot. Used by credit-lease
+   * callers that need the company's `credit_balances` so they can substitute
+   * a lease-bound view before calling the rules engine.
+   */
+  public async getCachedCompany(
+    keys: Record<string, string>,
+  ): Promise<Schematic.RulesengineCompany | null> {
+    return this.getCompanyFromCache(keys);
+  }
+
+  /** Public accessor for the cached user snapshot. */
+  public async getCachedUser(
+    keys: Record<string, string>,
+  ): Promise<Schematic.RulesengineUser | null> {
+    return this.getUserFromCache(keys);
+  }
+
+  /** Public accessor for the rules engine. Used by credit-lease eval. */
+  public getRulesEngine(): RulesEngineClient {
+    return this.rulesEngine;
   }
 
   /**
@@ -1354,7 +1382,8 @@ export class DataStreamClient extends LazyEmitter {
   private async evaluateFlag(
     flag: Schematic.RulesengineFlag,
     company: Schematic.RulesengineCompany | null,
-    user: Schematic.RulesengineUser | null
+    user: Schematic.RulesengineUser | null,
+    options?: CheckFlagOptions
   ): Promise<Schematic.RulesengineCheckFlagResult> {
     const defaultValue = flag.defaultValue ?? false;
 
@@ -1363,7 +1392,7 @@ export class DataStreamClient extends LazyEmitter {
       if (this.rulesEngine.isInitialized()) {
         this.logger.debug(`Evaluating flag with rules engine: ${JSON.stringify({ flagId: flag.id, flagRules: flag.rules?.length || 0, companyId: company?.id, userId: user?.id })}`);
 
-        const result = await this.rulesEngine.checkFlag(flag, company, user);
+        const result = await this.rulesEngine.checkFlagWithOptions(flag, company, user, options);
         this.logger.debug(`Rules engine evaluation result: ${JSON.stringify(result)}`);
 
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,14 @@ export { ConsoleLogger, LogLevel, type Logger } from "./logger";
 export { SchematicEnvironment } from "./environments";
 export { SchematicError, SchematicTimeoutError } from "./errors";
 export { RulesEngineClient } from "./rules-engine";
+export type {
+  CheckOptions,
+  CheckResult,
+  CreditLeaseConfig,
+  OnAcquireFailure,
+  Reservation,
+  TrackWithReservationOptions,
+} from "./credits";
 export {
   verifyWebhookSignature,
   verifySignature,

--- a/src/rules-engine.ts
+++ b/src/rules-engine.ts
@@ -1,4 +1,5 @@
-import * as Schematic from './api/types';
+import * as Schematic from "./api/types";
+import type { CheckFlagOptions } from "./wrapper";
 
 /** Entitlement details returned by the WASM rules engine  */
 export interface WasmFeatureEntitlement {
@@ -57,7 +58,7 @@ export class RulesEngineClient {
             // The loader is a CommonJS module (wasm-bindgen nodejs target), so
             // unwrap the interop `default` before reading the export.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const ns: any = await import('./wasm/rulesengine.js');
+            const ns: any = await import("./wasm/rulesengine.js");
             const wasm = ns.RulesEngineJS ? ns : (ns.default ?? ns);
             this.wasmInstance = new wasm.RulesEngineJS();
             this.initialized = true;
@@ -66,27 +67,29 @@ export class RulesEngineClient {
         }
     }
 
-    async checkFlag(
+    async checkFlag(flag: object, company?: object | null, user?: object | null): Promise<WasmCheckFlagResult> {
+        return this.checkFlagWithOptions(flag, company, user);
+    }
+
+    async checkFlagWithOptions(
         flag: object,
         company?: object | null,
-        user?: object | null
+        user?: object | null,
+        options?: CheckFlagOptions | null,
     ): Promise<WasmCheckFlagResult> {
         this.ensureInitialized();
 
         // Strip null values — WASM/Rust serde expects arrays not null, and
         // uses #[serde(default)] to default missing fields to empty values.
-        const stripNulls = (_key: string, value: unknown) => value === null ? undefined : value;
+        const stripNulls = (_key: string, value: unknown) => (value === null ? undefined : value);
 
         try {
             const flagJson = JSON.stringify(flag, stripNulls);
             const companyJson = company ? JSON.stringify(company, stripNulls) : undefined;
             const userJson = user ? JSON.stringify(user, stripNulls) : undefined;
+            const optionsJson = options ? JSON.stringify(serializeCheckFlagOptions(options), stripNulls) : undefined;
 
-            const resultJson = this.wasmInstance!.checkFlag(
-                flagJson,
-                companyJson,
-                userJson
-            );
+            const resultJson = this.wasmInstance!.checkFlagWithOptions(flagJson, companyJson, userJson, optionsJson);
 
             return JSON.parse(resultJson);
         } catch (error) {
@@ -112,9 +115,27 @@ export class RulesEngineClient {
 
     private ensureInitialized(): void {
         if (!this.initialized || !this.wasmInstance) {
-            throw new Error('WASM rules engine not initialized. Call initialize() first.');
+            throw new Error("WASM rules engine not initialized. Call initialize() first.");
         }
     }
+}
+
+// Serialize CheckFlagOptions to the snake_case envelope the WASM expects.
+function serializeCheckFlagOptions(options: CheckFlagOptions): Record<string, unknown> {
+    const envelope: Record<string, unknown> = {};
+    if (options.creditCost && Object.keys(options.creditCost).length > 0) {
+        envelope.credit_cost = options.creditCost;
+    }
+    if (options.usage !== undefined) {
+        envelope.usage = options.usage;
+    }
+    if (options.eventUsage) {
+        envelope.event_usage = {
+            event_subtype: options.eventUsage.eventSubtype,
+            quantity: options.eventUsage.quantity,
+        };
+    }
+    return envelope;
 }
 
 // Export for backward compatibility

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -9,6 +9,32 @@ import { offlineFetcher, provideFetcher } from "./core/fetcher/custom";
 import { RUNTIME } from "./core/runtime";
 import { DataStreamClient, type DataStreamClientOptions } from "./datastream";
 import type { RedisClient } from "./cache/redis";
+import {
+    CreditLeaseManager,
+    DEFAULT_PREWARM_POLL_INTERVAL_MS,
+    DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS,
+    DEFAULT_SWEEP_INTERVAL_MS,
+    LeaseStore,
+    RedisLeaseStore,
+    RedisReservationStore,
+    ReservationStore,
+    type ILeaseStore,
+    type IReservationStore,
+    type CheckOptions,
+    type CheckResult,
+    type CreditLeaseConfig,
+    type Reservation,
+    type TrackWithReservationOptions,
+} from "./credits";
+import { buildPreflightOptions, checkWithLease } from "./credits/check";
+import { buildReservationTrackEvent, consumeReservationAndBuildEvent } from "./credits/track";
+
+// Idempotency-key namespace for the Track event a reservation settles into.
+// Deterministic per reservation, so a recovery emit (work outlived the local
+// reservation TTL) and an accidental double `trackWithReservation` collapse to
+// one event server-side: the events pipeline dedupes by (account, env,
+// event_type, key) for 24h before any credit consumption runs.
+const RESERVATION_TRACK_IDEMPOTENCY_PREFIX = "lease-reservation:";
 
 /**
  * Configuration options for the SchematicClient
@@ -58,6 +84,15 @@ export interface SchematicOptions {
     offline?: boolean;
     /** The default maximum time to wait for a response in milliseconds */
     timeoutMs?: number;
+    /**
+     * Enable client-side credit lease + reservation behavior on `check` /
+     * `trackWithReservation`. Omit to keep the SDK lease-unaware.
+     *
+     * Lease-bearing checks require DataStream (or replicator mode) so the
+     * SDK has access to the cached flag + company state needed for local
+     * gating against the lease balance.
+     */
+    creditLeases?: CreditLeaseConfig;
 }
 
 export interface CheckFlagOptions {
@@ -65,6 +100,24 @@ export interface CheckFlagOptions {
     defaultValue?: boolean | (() => boolean);
     /** The maximum time to wait for a response in milliseconds */
     timeoutMs?: number;
+    /**
+     * Preflight inputs forwarded to the WASM rules engine's
+     * `checkFlagWithOptions`. The engine picks the most specific knob for each
+     * condition it evaluates. Only applied when the flag is evaluated locally
+     * (DataStream); the REST fallback path does not support preflight and
+     * ignores these. No reservation is issued — for lease-backed gating use
+     * `check()` instead.
+     */
+    /** Pre-computed per-credit-id cost. Highest precedence for credit-balance gates. */
+    creditCost?: Record<string, number>;
+    /** Single integer quantity applied to whatever numeric condition is being evaluated. */
+    usage?: number;
+    /**
+     * Simulated quantity scoped to a specific event subtype. Preferred over
+     * `usage` when the subtype is known. Deliberately singular: one check
+     * preflights one action.
+     */
+    eventUsage?: { eventSubtype: string; quantity: number };
 }
 
 /**
@@ -89,6 +142,14 @@ export interface TrackOptions {
 export interface IdentifyOptions {
     /** Client-supplied dedupe key. Duplicate events with the same key (scoped to the environment) are dropped server-side for 24 hours. */
     idempotencyKey?: string;
+    /**
+     * Credit type IDs to acquire leases for in the background after the
+     * identify event is enqueued. Fire-and-forget — failures are logged but
+     * never surface to the caller. Equivalent to calling `client.prewarm()`
+     * directly with the same evalCtx and creditTypeIds. No-op unless
+     * `creditLeases` is configured on the client.
+     */
+    prewarm?: string[];
 }
 
 export interface CheckFlagWithEntitlementResponse {
@@ -111,6 +172,13 @@ export class SchematicClient extends BaseClient {
     private flagDefaults: { [key: string]: boolean };
     private logger: Logger;
     private offline: boolean;
+    private creditLeaseManager?: CreditLeaseManager;
+    private leaseStore?: ILeaseStore;
+    private reservations?: IReservationStore;
+    // True when lease state lives in a shared (Redis) backend that sibling
+    // pods may also be drawing on — close() must then NOT release leases.
+    private leaseBackendShared: boolean = false;
+    private prewarmResolveTimeoutMs: number = DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS;
 
     /**
      * Creates a new instance of the SchematicClient
@@ -193,7 +261,9 @@ export class SchematicClient extends BaseClient {
             logger,
             offline,
         });
-        this.flagCheckCacheProviders = opts?.cacheProviders?.flagChecks ?? [new LocalCache<CheckFlagWithEntitlementResponse>()];
+        this.flagCheckCacheProviders = opts?.cacheProviders?.flagChecks ?? [
+            new LocalCache<CheckFlagWithEntitlementResponse>(),
+        ];
         this.flagDefaults = flagDefaults;
         this.offline = offline;
 
@@ -206,8 +276,8 @@ export class SchematicClient extends BaseClient {
             if (isEdgeRuntime && !isReplicatorMode) {
                 logger.warn(
                     `DataStream is not supported in ${RUNTIME.type} runtime and will be disabled. ` +
-                    `DataStream requires Node.js APIs (WebSocket) that are not available in edge/browser environments. ` +
-                    `Use replicatorMode for edge runtime compatibility.`
+                        `DataStream requires Node.js APIs (WebSocket) that are not available in edge/browser environments. ` +
+                        `Use replicatorMode for edge runtime compatibility.`,
                 );
             } else {
                 const datastreamOptions: DataStreamClientOptions = {
@@ -227,8 +297,77 @@ export class SchematicClient extends BaseClient {
                     logger.error(`Failed to start DataStream client: ${error}`);
                     this.datastreamClient = undefined;
                 });
-
             }
+        }
+
+        // Set up credit lease + reservation plumbing if the caller opted in.
+        if (opts?.creditLeases && offline) {
+            logger.warn(
+                "creditLeases is configured but the client is in offline mode — lease-gated checks are " +
+                    "disabled and check() will return flag defaults with no credit gating.",
+            );
+        }
+        if (opts?.creditLeases && !offline) {
+            // Lease-bearing checks evaluate locally against the datastream's
+            // cached flag + company state. Without it, every check() silently
+            // falls back to a plain flag check — usage is ignored and no credit
+            // gating happens — so surface the misconfiguration once, loudly,
+            // instead of a per-check debug line.
+            if (!this.datastreamClient) {
+                logger.warn(
+                    "creditLeases is configured but DataStream is not enabled — check() will fall back to " +
+                        "plain flag checks with NO credit gating (usage is ignored). Set useDataStream: true " +
+                        "(or replicatorMode) to enable lease-gated checks.",
+                );
+            }
+            const sweepMs = opts.creditLeases.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+            // Lease + reservation state belongs in a shared cache so gating
+            // holds across horizontally-scaled pods. Prefer an explicit
+            // `creditLeases.redisClient`, but otherwise reuse the Redis client
+            // the DataStream cache is already configured with — so an existing
+            // Redis setup backs leases automatically, with no second client to
+            // wire up. Same for the key prefix.
+            const redisClient = opts.creditLeases.redisClient ?? opts.dataStream?.redisClient;
+            const keyPrefix = opts.creditLeases.redisKeyPrefix ?? opts.dataStream?.redisKeyPrefix;
+            if (redisClient) {
+                // Shared-state backend: lease balance + reservation table live
+                // in Redis. Lua-script-driven atomicity gives cross-pod gating
+                // without a separate lock service.
+                this.leaseBackendShared = true;
+                this.leaseStore = new RedisLeaseStore({
+                    client: redisClient,
+                    keyPrefix,
+                    defaultLeaseDurationMs: opts.creditLeases.defaultLeaseDuration,
+                });
+                this.reservations = new RedisReservationStore({
+                    client: redisClient,
+                    leaseStore: this.leaseStore,
+                    sweepIntervalMs: sweepMs,
+                    keyPrefix,
+                });
+            } else {
+                // No shared backend configured: fall back to per-process
+                // in-memory stores. In a horizontally-scaled deployment each pod
+                // then acquires and gates against its own leases, which defeats
+                // the cross-pod over-spend protection that is the point of
+                // leasing — so warn rather than degrade silently.
+                logger.warn(
+                    "creditLeases is enabled without a shared Redis backend; lease and reservation " +
+                        "state will be kept per-process. Configure dataStream.redisClient (or " +
+                        "creditLeases.redisClient) so leases gate correctly across multiple SDK instances.",
+                );
+                this.leaseStore = new LeaseStore();
+                this.reservations = new ReservationStore(this.leaseStore, sweepMs);
+            }
+            this.reservations.startSweep();
+            this.creditLeaseManager = new CreditLeaseManager({
+                creditsClient: this.credits,
+                leaseStore: this.leaseStore,
+                logger,
+                config: opts.creditLeases,
+            });
+            this.prewarmResolveTimeoutMs =
+                opts.creditLeases.prewarmResolveTimeoutMs ?? DEFAULT_PREWARM_RESOLVE_TIMEOUT_MS;
         }
     }
 
@@ -282,7 +421,7 @@ export class SchematicClient extends BaseClient {
 
         if (this.useDataStream()) {
             try {
-                const resp = await this.datastreamClient!.checkFlag(evalCtx, key);
+                const resp = await this.datastreamClient!.checkFlag(evalCtx, key, options);
 
                 // Enqueue the flag check event
                 this.enqueueEvent(api.EventType.FlagCheck, {
@@ -392,12 +531,14 @@ export class SchematicClient extends BaseClient {
      */
     async checkFlags(evalCtx: api.CheckFlagRequestBody, keys?: string[]): Promise<api.CheckFlagResponseData[]> {
         if (this.offline) {
-            this.logger.debug(`Offline mode enabled, returning default flag values for flags ${keys ? keys.join(', ') : 'all'}`);
+            this.logger.debug(
+                `Offline mode enabled, returning default flag values for flags ${keys ? keys.join(", ") : "all"}`,
+            );
             if (keys && keys.length > 0) {
-                return keys.map(key => ({
+                return keys.map((key) => ({
                     flag: key,
                     value: this.getFlagDefault(key),
-                    reason: 'Offline mode - using default value'
+                    reason: "Offline mode - using default value",
                 }));
             } else {
                 // In offline mode with no keys, return empty array
@@ -417,7 +558,7 @@ export class SchematicClient extends BaseClient {
 
             // If no keys provided or empty array, call standard checkFlags
             if (!keys || keys.length === 0) {
-                this.logger.debug('No specific flag keys provided, calling standard checkFlags API');
+                this.logger.debug("No specific flag keys provided, calling standard checkFlags API");
                 const response = await this.features.checkFlags(evalCtx);
                 return response.data.flags;
             }
@@ -452,11 +593,11 @@ export class SchematicClient extends BaseClient {
             // If all keys were found in cache, return cached results
             if (missingKeys.length === 0) {
                 this.logger.debug(`All ${keys.length} flags found in cache`);
-                return keys.map(key => cachedResults.get(key)!);
+                return keys.map((key) => cachedResults.get(key)!);
             }
 
             // Call API for missing keys by calling standard checkFlags and filtering results
-            this.logger.debug(`Cache miss for ${missingKeys.length} flags: ${missingKeys.join(', ')}, calling API`);
+            this.logger.debug(`Cache miss for ${missingKeys.length} flags: ${missingKeys.join(", ")}, calling API`);
             const response = await this.features.checkFlags(evalCtx);
             const apiResults = response.data.flags;
 
@@ -466,7 +607,7 @@ export class SchematicClient extends BaseClient {
 
             for (const key of keys) {
                 // Find result from API response first (prioritize fresh data)
-                const apiResult = apiResults.find(flag => flag.flag === key);
+                const apiResult = apiResults.find((flag) => flag.flag === key);
                 if (apiResult) {
                     // Cache the fresh result
                     const cacheKey = JSON.stringify({ evalCtx, key });
@@ -502,25 +643,26 @@ export class SchematicClient extends BaseClient {
                         const defaultResult: api.CheckFlagResponseData = {
                             flag: key,
                             value: this.getFlagDefault(key),
-                            reason: 'Flag not found - using default value'
+                            reason: "Flag not found - using default value",
                         };
                         results.push(defaultResult);
                     }
                 }
             }
 
-            this.logger.debug(`Checked ${keys.length} flags: used fresh API values for consistency (${missingKeys.length} were cache misses)`);
+            this.logger.debug(
+                `Checked ${keys.length} flags: used fresh API values for consistency (${missingKeys.length} were cache misses)`,
+            );
             return results;
-
         } catch (err) {
-            this.logger.error(`Error checking flags ${keys ? keys.join(', ') : 'all'}: ${err}`);
-            
+            this.logger.error(`Error checking flags ${keys ? keys.join(", ") : "all"}: ${err}`);
+
             // Return default values for all requested keys
             if (keys && keys.length > 0) {
-                return keys.map(key => ({
+                return keys.map((key) => ({
                     flag: key,
                     value: this.getFlagDefault(key),
-                    reason: `Error occurred - using default value: ${err}`
+                    reason: `Error occurred - using default value: ${err}`,
                 }));
             } else {
                 return [];
@@ -566,10 +708,28 @@ export class SchematicClient extends BaseClient {
     }
 
     /**
-     * Gracefully shuts down the client by stopping the event buffer and DataStream client
+     * Gracefully shuts down the client by stopping the event buffer, the
+     * reservation sweeper, and the DataStream client.
+     *
+     * Credit leases: with the per-process in-memory backend, this process is
+     * the only holder of its leases, so they are released here (best-effort) —
+     * their unspent remainder returns to the company balance immediately
+     * instead of waiting out the lease expiry. With a shared (Redis) backend,
+     * leases are deliberately *not* released: a lease is shared across every
+     * SDK instance pointed at the same backend (one row per company+credit),
+     * so a single pod shutting down must not release a lease that sibling pods
+     * are still drawing on — doing so would refund the grant server-side and
+     * pull the balance out from under them. Shared leases reclaim themselves:
+     * they expire (client- and server-side) or are fully consumed.
      * @returns Promise that resolves when everything has been stopped
      */
     async close(): Promise<void> {
+        if (this.reservations) {
+            this.reservations.stop();
+        }
+        if (this.creditLeaseManager && !this.leaseBackendShared) {
+            await this.creditLeaseManager.releaseAllLocalLeases();
+        }
         if (this.datastreamClient) {
             this.datastreamClient.close();
         }
@@ -577,11 +737,320 @@ export class SchematicClient extends BaseClient {
     }
 
     /**
-     * Send a non-blocking event to create or update companies and users
-     * @param body - The identify event payload containing user properties
-     * @param options - Optional event metadata (e.g. idempotencyKey)
-     * @returns Promise that resolves when the event has been enqueued
-     * @throws Will log error if event enqueueing fails
+     * Pre-warm a credit lease for each given credit type ID, so the first
+     * `check()` against it doesn't pay the acquire round-trip. Fire-and-forget
+     * — failures are logged but don't throw.
+     *
+     * When `evalCtx.company` carries only secondary keys (no `id`), `prewarm`
+     * actively fetches the company over the datastream (waiting up to
+     * `creditLeases.prewarmResolveTimeoutMs` for the WS to connect), which both
+     * resolves the id and warms the cache so the first `check()` hits the lease
+     * path. Covers a brand-new company too: the fetch retries until the server
+     * has ingested the preceding `identify` and can stream it back.
+     */
+    async prewarm(evalCtx: api.CheckFlagRequestBody, creditTypeIds: string[]): Promise<void> {
+        if (!this.creditLeaseManager || !this.leaseStore) {
+            this.logger.debug("prewarm called but creditLeases is not configured");
+            return;
+        }
+        if (!evalCtx.company || Object.keys(evalCtx.company).length === 0) {
+            this.logger.debug("prewarm requires a company on evalCtx");
+            return;
+        }
+        const companyId = await this.resolveCompanyIdWithWait(evalCtx);
+        if (!companyId) {
+            this.logger.debug(
+                `prewarm: company not resolved within ${this.prewarmResolveTimeoutMs}ms for keys ${JSON.stringify(evalCtx.company)} (first check() will acquire)`,
+            );
+            return;
+        }
+        await Promise.all(
+            creditTypeIds.map((id) =>
+                this.creditLeaseManager!.acquireIfNeeded(companyId, id).catch((err) =>
+                    this.logger.warn(`prewarm: failed to acquire lease for ${id}: ${err}`),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Like `resolveCompanyId` but actively fetches the company over the
+     * datastream when only secondary keys are supplied, warming the cache as a
+     * side effect. Returns the resolved id, or undefined if the company never
+     * surfaced within `prewarmResolveTimeoutMs`.
+     *
+     * `identify` does not push a company into the datastream cache —  companies
+     * are only streamed in response to a request. So we call `getCompany`
+     * (cache-first, then sends the request and awaits the push) rather than
+     * passively polling `getCachedCompany`, which would watch an empty cache
+     * until it times out. Fetching also primes the cache so the first real
+     * `check()` hits the lease path instead of falling back.
+     */
+    private async resolveCompanyIdWithWait(evalCtx: api.CheckFlagRequestBody): Promise<string | undefined> {
+        if (!evalCtx.company) return undefined;
+        if (evalCtx.company.id) return evalCtx.company.id;
+        const datastream = this.datastreamClient;
+        if (!datastream || this.prewarmResolveTimeoutMs <= 0) {
+            return this.resolveCompanyId(evalCtx);
+        }
+        const company = evalCtx.company;
+        // Fast path — already cached by an earlier check or prewarm.
+        const cached = await datastream.getCachedCompany(company);
+        if (cached?.id) return cached.id;
+        // Actively fetch. Retry across the brief WS-connecting window at boot
+        // (getCompany throws "not connected" until the socket is ready),
+        // bounded by prewarmResolveTimeoutMs.
+        const deadline = Date.now() + this.prewarmResolveTimeoutMs;
+        for (;;) {
+            try {
+                const resolved = await datastream.getCompany(company);
+                if (resolved?.id) return resolved.id;
+            } catch (err) {
+                this.logger.debug(`prewarm: datastream company fetch failed (${err})`);
+            }
+            if (Date.now() >= deadline) return undefined;
+            await new Promise((r) => setTimeout(r, DEFAULT_PREWARM_POLL_INTERVAL_MS));
+        }
+    }
+
+    /**
+     * Lease-aware feature check. When `creditLeases` is configured and the
+     * caller passes `usage` (optionally qualified by `eventSubtype`), this
+     * acquires a lease (if needed), gates the check against the lease's local
+     * balance via WASM, and returns a reservation handle on success — pass
+     * that handle to `trackWithReservation` when the work completes.
+     *
+     * When `creditLeases` is not configured (or `usage` is omitted) this falls
+     * through to a plain flag check and returns `{allowed: value}` with no
+     * reservation, byte-compatible with `checkFlag` semantics. The caller's
+     * preflight (`usage` / `eventSubtype`) is still threaded through the plain
+     * check, so any client-side evaluation path (datastream, replicator)
+     * gates on the post-call balance — just without a reservation. Only the
+     * REST fallback ignores preflight.
+     */
+    async check(evalCtx: api.CheckFlagRequestBody, key: string, options?: CheckOptions): Promise<CheckResult> {
+        const fallback = async (): Promise<CheckResult> => {
+            const resp = await this.checkFlagWithEntitlement(evalCtx, key, {
+                defaultValue: options?.defaultValue,
+                timeoutMs: options?.timeoutMs,
+                ...(options ? buildPreflightOptions(options) : undefined),
+            });
+            return {
+                allowed: resp.value,
+                value: resp.value,
+                reason: resp.reason,
+                entitlement: resp.entitlement,
+                flagKey: resp.flagKey,
+                flagId: resp.flagId,
+                err: resp.err,
+            };
+        };
+
+        const hasPreflight = options?.usage !== undefined;
+        if (!hasPreflight || !this.creditLeaseManager || !this.leaseStore || !this.reservations) {
+            return fallback();
+        }
+
+        return checkWithLease(
+            {
+                leaseStore: this.leaseStore,
+                reservations: this.reservations,
+                manager: this.creditLeaseManager,
+                datastream: this.datastreamClient,
+                logger: this.logger,
+                // Lease-path checks must stay visible to flag-check analytics
+                // and company last-seen, same as every plain checkFlag path.
+                enqueueFlagCheckEvent: (body) => this.enqueueEvent(api.EventType.FlagCheck, body),
+            },
+            key,
+            evalCtx,
+            options,
+            fallback,
+        );
+    }
+
+    /**
+     * Consume a reservation issued by `check()`. Refunds the unused slice
+     * (`creditsReserved - actualQuantity * consumptionRate`) back to the
+     * lease's local balance and enqueues a Track event with
+     * `quantity = actualQuantity`. The server-side event processor consumes
+     * `actualQuantity × consumption_rate` from the company's real credit
+     * balance.
+     *
+     * If the work outlived the reservation's TTL and the sweeper already
+     * returned the hold to the lease, the local refund has happened but the
+     * usage must still be billed — so we emit the Track anyway (a "recovery"
+     * emit). The server bills it against the lease's sub-ledger if the lease is
+     * still live, or falls through to a direct grant decrement if the server
+     * lease has itself expired.
+     *
+     * Double-billing is prevented server-side: the Track carries a deterministic
+     * `idempotencyKey` derived from the reservation id, and the events pipeline
+     * drops duplicates by `(account, env, event_type, key)` for 24h before any
+     * credit consumption runs. So a recovery emit racing the normal emit, or an
+     * accidental second `trackWithReservation`, collapses to a single billed
+     * event — across pods and process restarts, not just within one process.
+     */
+    async trackWithReservation(
+        reservation: Reservation,
+        actualQuantity: number,
+        options?: TrackWithReservationOptions,
+    ): Promise<void> {
+        if (this.offline) return;
+        // Mirror the check-path usage guard: a non-finite quantity must reach
+        // neither the store (`Math.min(NaN, reserved)` claims the reservation
+        // with NO refund of the unspent slice) nor the billing event (NaN
+        // serializes to `quantity: null`); a negative one would bill negative
+        // usage. Skip the settle entirely — the untouched reservation expires
+        // at its TTL and the sweeper refunds the full hold, so no credits are
+        // lost and nothing bogus is billed.
+        if (!Number.isFinite(actualQuantity) || actualQuantity < 0) {
+            this.logger.error(
+                `trackWithReservation: invalid actualQuantity ${actualQuantity} for reservation ${reservation.id} ` +
+                    `— must be a finite, non-negative number; skipping settle (the hold is refunded at its TTL)`,
+            );
+            return;
+        }
+        if (!this.reservations) {
+            this.logger.warn(
+                "trackWithReservation called but creditLeases is not configured — emitting unsettled track",
+            );
+            // No local store to settle against, but the billing event must
+            // still carry the `leaseId` (the handle was issued by a
+            // lease-configured client — dropping it would double-debit the
+            // grant) and the deterministic idempotency key (so a duplicate
+            // emit still dedupes server-side).
+            await this.track(buildReservationTrackEvent(reservation, actualQuantity, options), {
+                idempotencyKey: `${RESERVATION_TRACK_IDEMPOTENCY_PREFIX}${reservation.id}`,
+            });
+            return;
+        }
+        let track: api.EventBodyTrack;
+        let settledLocally: boolean;
+        try {
+            ({ track, settledLocally } = await consumeReservationAndBuildEvent(
+                this.reservations,
+                reservation,
+                actualQuantity,
+                options,
+            ));
+        } catch (err) {
+            // The local settle (store consume/refund) failed — likely an
+            // unreachable Redis. The usage still has to be billed: build the
+            // Track from the caller-held handle and emit it anyway. The
+            // un-settled local hold is reclaimed by the sweeper at its TTL or
+            // at lease expiry; the idempotency key below keeps a retried
+            // settle from double-billing.
+            this.logger.warn(
+                `trackWithReservation: failed to settle reservation ${reservation.id} locally (${err}) — emitting track anyway`,
+            );
+            track = buildReservationTrackEvent(reservation, actualQuantity, options);
+            settledLocally = false;
+        }
+        if (!settledLocally) {
+            this.logger.debug(
+                `trackWithReservation: reservation ${reservation.id} was not settled locally (expired/swept, already settled, or store unreachable) — emitting track keyed for idempotent server-side dedupe`,
+            );
+        }
+        // Deterministic idempotency key so duplicate/recovery emits dedupe
+        // server-side rather than double-billing the lease's sub-ledger.
+        await this.track(track, {
+            idempotencyKey: `${RESERVATION_TRACK_IDEMPOTENCY_PREFIX}${reservation.id}`,
+        });
+    }
+
+    /**
+     * Lease-aware credit balance for display, in the same three-way split the
+     * server exposes on `listCompanyCreditBalances`:
+     *
+     *   - `remaining`: credits available to draw right now — the server balance
+     *     (`company.creditBalances[creditId]`, already net of any active lease
+     *     tranche): `B − L`.
+     *   - `reserved`: the active lease's unsettled hold — its unspent local
+     *     balance plus open reservations (`L − spent`), reported as the
+     *     aggregate the server models.
+     *   - `settled`: the economic balance the end user should see —
+     *     `remaining + reserved = B − spent`. Invariant to in-flight holds, so
+     *     a counter bound to it doesn't dip mid-call.
+     *
+     * Bind a user-facing "credits remaining" counter to `settled`: the server
+     * balance alone reads low (or 0) while a lease still has unspent balance.
+     *
+     * `reserved` is 0 when no lease is held or the held lease has expired — the
+     * server refunds an expired lease's unspent hold into the balance, so
+     * counting a stale local entry would double-count. Returns zeros when
+     * credit leases / datastream aren't configured or the company can't be
+     * resolved. The `reserved` term comes from this process's lease +
+     * reservation stores, so it (and `settled`) is per-process unless
+     * Redis-backed stores are configured.
+     */
+    async getCreditBalance(
+        company: Record<string, string>,
+        creditId: string,
+    ): Promise<{ remaining: number; reserved: number; settled: number }> {
+        const empty = { remaining: 0, reserved: 0, settled: 0 };
+        const datastream = this.datastreamClient;
+        if (!datastream || !company || Object.keys(company).length === 0) {
+            return empty;
+        }
+
+        let snapshot = await datastream.getCachedCompany(company);
+        if (!snapshot) {
+            // Not cached yet (e.g. first paint before any check/prewarm).
+            // Actively fetch so the counter populates; tolerate a cold/closed
+            // datastream by returning zeros rather than throwing.
+            try {
+                snapshot = await datastream.getCompany(company);
+            } catch (err) {
+                this.logger.debug(`getCreditBalance: company fetch failed (${err})`);
+                return empty;
+            }
+        }
+        if (!snapshot?.id) return empty;
+
+        // `remaining` = the drawable pool = the server balance, already net of
+        // any active lease tranche (`B − L`).
+        const remaining = snapshot.creditBalances?.[creditId] ?? 0;
+        // Display path: tolerate an unreachable lease store by reporting no
+        // local hold rather than throwing.
+        const leaseEntry = await Promise.resolve()
+            .then(() => this.leaseStore?.get(snapshot.id, creditId))
+            .catch((err) => {
+                this.logger.debug(`getCreditBalance: lease store read failed (${err})`);
+                return undefined;
+            });
+        // Only count a live lease. Past expiresAt the server has (or imminently
+        // will) sweep and refund the hold, so `remaining` already accounts for it.
+        const leaseLive = leaseEntry !== undefined && new Date(leaseEntry.expiresAt).getTime() > Date.now();
+        // `reserved` = the lease's whole unsettled hold (`L − spent`): its
+        // unspent local balance plus its open reservations. Both are 0 without
+        // a live lease.
+        const leaseRemainder = leaseLive ? leaseEntry.localRemainingCredits : 0;
+        const openReservations = leaseLive
+            ? ((await this.reservations?.reservedCredits(snapshot.id, creditId)) ?? 0)
+            : 0;
+        const reserved = leaseRemainder + openReservations;
+
+        return { remaining, reserved, settled: remaining + reserved };
+    }
+
+    private async resolveCompanyId(evalCtx: api.CheckFlagRequestBody): Promise<string | undefined> {
+        if (!evalCtx.company) return undefined;
+        // If the caller passed `id`, use that directly.
+        if (evalCtx.company.id) return evalCtx.company.id;
+        // Otherwise, the datastream cache can resolve secondary keys → id.
+        if (this.datastreamClient) {
+            const cached = await this.datastreamClient.getCachedCompany(evalCtx.company);
+            return cached?.id;
+        }
+        return undefined;
+    }
+
+    /**
+     * Send a non-blocking event to create or update companies and users.
+     * Pass `options.prewarm` with credit type IDs to kick off lease acquires in
+     * the background after the identify event is enqueued (no-op unless
+     * `creditLeases` is configured on the client).
      */
     async identify(body: api.EventBodyIdentify, options?: IdentifyOptions): Promise<void> {
         if (this.offline) return;
@@ -590,6 +1059,23 @@ export class SchematicClient extends BaseClient {
             await this.enqueueEvent("identify", body, options);
         } catch (err) {
             this.logger.error(`Error sending identify event: ${err}`);
+        }
+
+        if (options?.prewarm && options.prewarm.length > 0) {
+            const evalCtx: api.CheckFlagRequestBody = {
+                company: body.company?.keys,
+                user: body.keys,
+            };
+            // Force-flush so the server processes the identify ASAP — without
+            // it, the company may sit in the local buffer for up to the
+            // buffer's flush interval before the server even sees it, and
+            // prewarm's bounded poll would just be waiting on us. Fire-and-forget.
+            void this.eventBuffer.flush().catch((err) => {
+                this.logger.debug(`identify flush before prewarm failed: ${err}`);
+            });
+            void this.prewarm(evalCtx, options.prewarm).catch((err) => {
+                this.logger.warn(`identify prewarm failed: ${err}`);
+            });
         }
     }
 
@@ -609,11 +1095,7 @@ export class SchematicClient extends BaseClient {
             // Update company metrics in DataStream if available and connected
             if (body.company && this.useDataStream() && this.datastreamClient!.isConnected()) {
                 try {
-                    await this.datastreamClient!.updateCompanyMetrics(
-                        body.company,
-                        body.event,
-                        body.quantity || 1
-                    );
+                    await this.datastreamClient!.updateCompanyMetrics(body.company, body.event, body.quantity || 1);
                 } catch (err) {
                     this.logger.error(`Failed to update company metrics: ${err}`);
                 }

--- a/tests/integration/redis-stores.test.ts
+++ b/tests/integration/redis-stores.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Integration tests for the Redis-backed lease + reservation stores against a
+ * REAL redis-server — the only place the Lua scripts are executed as Lua.
+ *
+ * The unit suite exercises these stores against `fake-redis`, which matches
+ * each script by substring and re-implements its semantics in JS; a Lua syntax
+ * error or a semantic drift between script and fake would ship green there.
+ * This suite is the backstop: it runs the actual scripts (including the
+ * `redis.call('TIME')` server-clock read and the string-vs-integer reply
+ * conversions) under real concurrency.
+ *
+ * Opt-in: set TEST_REDIS_URL (e.g. redis://localhost:6379) to enable. CI runs
+ * it against a redis service container; locally the suite skips when unset so
+ * `yarn test` stays dependency-free.
+ */
+import { randomUUID } from "crypto";
+
+import { createClient } from "redis";
+
+import type { RedisClient } from "../../src/cache/redis";
+import { RedisLeaseStore } from "../../src/credits/redis-lease-store";
+import { RedisReservationStore } from "../../src/credits/redis-reservation-store";
+import type { Reservation } from "../../src/credits/types";
+
+const REDIS_URL = process.env.TEST_REDIS_URL;
+const describeIf = REDIS_URL ? describe : describe.skip;
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+    return {
+        id: randomUUID(),
+        leaseId: "lse_1",
+        companyId: "co_1",
+        creditTypeId: "ct_1",
+        eventSubtype: "inference_tokens",
+        quantityReserved: 10,
+        creditsReserved: 100,
+        consumptionRate: 10,
+        expiresAt: new Date(Date.now() + 60_000),
+        evalCtx: { company: { id: "co_1" } },
+        ...overrides,
+    };
+}
+
+describeIf("Redis stores against a real redis-server", () => {
+    jest.setTimeout(15_000);
+
+    let rawClient: ReturnType<typeof createClient>;
+    let client: RedisClient;
+    // Unique prefix per run so concurrent/leftover runs can't interfere; all
+    // keys are swept in afterAll.
+    const keyPrefix = `schematic-test:${randomUUID()}:`;
+
+    beforeAll(async () => {
+        rawClient = createClient({ url: REDIS_URL });
+        await rawClient.connect();
+        client = rawClient as unknown as RedisClient;
+    });
+
+    afterAll(async () => {
+        if (!rawClient?.isOpen) return;
+        const stale: string[] = [];
+        for await (const key of rawClient.scanIterator({ MATCH: `${keyPrefix}*`, COUNT: 100 })) {
+            stale.push(key);
+        }
+        if (stale.length > 0) await rawClient.del(stale);
+        await rawClient.quit();
+    });
+
+    function makeLeaseStore(): RedisLeaseStore {
+        return new RedisLeaseStore({ client, keyPrefix });
+    }
+
+    function makeStores(): { leaseStore: RedisLeaseStore; reservations: RedisReservationStore } {
+        const leaseStore = makeLeaseStore();
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000, keyPrefix });
+        return { leaseStore, reservations };
+    }
+
+    async function installLease(
+        leaseStore: RedisLeaseStore,
+        opts: { creditTypeId?: string; leaseId?: string; grantedAmount?: number; expiresAt?: Date } = {},
+    ): Promise<string> {
+        const creditTypeId = opts.creditTypeId ?? `ct_${randomUUID()}`;
+        const wrote = await leaseStore.replace({
+            leaseId: opts.leaseId ?? "lse_1",
+            companyId: "co_1",
+            creditTypeId,
+            grantedAmount: opts.grantedAmount ?? 100,
+            expiresAt: opts.expiresAt ?? new Date(Date.now() + 60_000),
+        });
+        expect(wrote).toBe(true);
+        return creditTypeId;
+    }
+
+    it("replace round-trips, keeps a live lease, and overwrites an expired one", async () => {
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { leaseId: "lse_a", grantedAmount: 100 });
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 40)).toBe(60);
+
+        // A racing acquire must not clobber the live, partially-debited lease.
+        const wroteOverLive = await leaseStore.replace({
+            leaseId: "lse_b",
+            companyId: "co_1",
+            creditTypeId,
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wroteOverLive).toBe(false);
+        let entry = await leaseStore.get("co_1", creditTypeId);
+        expect(entry?.leaseId).toBe("lse_a");
+        expect(entry?.localRemainingCredits).toBe(60);
+
+        // An expired slot is fair game (expiry judged by the Redis server clock).
+        await client.hSet(leaseStore.hashKey("co_1", creditTypeId), "expiresAt", String(Date.now() - 1_000));
+        const wroteOverExpired = await leaseStore.replace({
+            leaseId: "lse_b",
+            companyId: "co_1",
+            creditTypeId,
+            grantedAmount: 200,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wroteOverExpired).toBe(true);
+        entry = await leaseStore.get("co_1", creditTypeId);
+        expect(entry?.leaseId).toBe("lse_b");
+        expect(entry?.localRemainingCredits).toBe(200);
+    });
+
+    it("tryReserve under contention admits exactly the available balance", async () => {
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { grantedAmount: 100 });
+
+        // 25 concurrent reserves of 10 against 100: exactly 10 may win.
+        const results = await Promise.all(
+            Array.from({ length: 25 }, () => leaseStore.tryReserve("co_1", creditTypeId, 10)),
+        );
+        const successes = results.filter((r): r is number => r !== null);
+        expect(successes).toHaveLength(10);
+        // Each success returns the post-debit balance: one distinct step each.
+        expect([...successes].sort((a, b) => a - b)).toEqual([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]);
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(0);
+    });
+
+    it("tryReserve preserves fractional balances across the string reply", async () => {
+        // A Lua number reply truncates to integer — the script must return the
+        // balance as a string for fractional consumption rates to survive.
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { grantedAmount: 10 });
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 0.5)).toBe(9.5);
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(9.5);
+    });
+
+    it("tryReserve rejects an expired-but-not-yet-evicted lease (TTL grace window)", async () => {
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { expiresAt: new Date(Date.now() + 150) });
+        await new Promise((r) => setTimeout(r, 250));
+        // Row still present (grace keeps it for the sweeper)...
+        expect(await leaseStore.get("co_1", creditTypeId)).toBeDefined();
+        // ...but the server-clock expiry guard refuses to reserve against it.
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 10)).toBeNull();
+    });
+
+    it("refund clamps at grantedAmount and honors the leaseId pin", async () => {
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { leaseId: "lse_live", grantedAmount: 100 });
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 50)).toBe(50);
+
+        // Pinned to a stale lease: dropped.
+        await leaseStore.refund("co_1", creditTypeId, 30, "lse_stale");
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(50);
+        // Pinned to the live lease: applies.
+        await leaseStore.refund("co_1", creditTypeId, 30, "lse_live");
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(80);
+        // Clamped at grantedAmount.
+        await leaseStore.refund("co_1", creditTypeId, 9_999);
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(100);
+    });
+
+    it("extend reconciles to the server total and honors the leaseId pin", async () => {
+        const leaseStore = makeLeaseStore();
+        const creditTypeId = await installLease(leaseStore, { leaseId: "lse_live", grantedAmount: 100 });
+
+        // Pinned to a stale lease: dropped.
+        await leaseStore.extend("co_1", creditTypeId, 150, new Date(Date.now() + 120_000), "lse_stale");
+        let entry = await leaseStore.get("co_1", creditTypeId);
+        expect(entry?.grantedAmount).toBe(100);
+
+        // Pinned to the live lease: reconciles to the total (credits the delta).
+        const farExpiry = new Date(Date.now() + 120_000);
+        await leaseStore.extend("co_1", creditTypeId, 150, farExpiry, "lse_live");
+        entry = await leaseStore.get("co_1", creditTypeId);
+        expect(entry?.grantedAmount).toBe(150);
+        expect(entry?.localRemainingCredits).toBe(150);
+
+        // A concurrent sibling's superseded total is a no-op — no
+        // double-counted delta, and the expiry never moves backwards.
+        await leaseStore.extend("co_1", creditTypeId, 120, new Date(Date.now() + 60_000), "lse_live");
+        entry = await leaseStore.get("co_1", creditTypeId);
+        expect(entry?.grantedAmount).toBe(150);
+        expect(entry?.localRemainingCredits).toBe(150);
+        expect(entry?.expiresAt.getTime()).toBe(farExpiry.getTime());
+    });
+
+    it("concurrent consumes settle a reservation exactly once", async () => {
+        const { leaseStore, reservations } = makeStores();
+        const creditTypeId = await installLease(leaseStore, { grantedAmount: 1_000 });
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 100)).toBe(900);
+        const reservation = makeReservation({ creditTypeId });
+        await reservations.add(reservation);
+
+        // Five racing settles (e.g. a Track racing sweepers): the CLAIM script
+        // arbitrates — exactly one wins and refunds the unused slice once.
+        const results = await Promise.all(Array.from({ length: 5 }, () => reservations.consume(reservation.id, 60)));
+        expect(results.filter((r) => r !== null)).toEqual([60]);
+        // 40 unused credits refunded exactly once: 900 + 40.
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(940);
+        expect(await reservations.reservedCredits("co_1", creditTypeId)).toBe(0);
+        reservations.stop();
+    });
+
+    it("sweepExpired refunds expired holds and cleans both indexes", async () => {
+        const { leaseStore, reservations } = makeStores();
+        const creditTypeId = await installLease(leaseStore, { grantedAmount: 1_000 });
+        expect(await leaseStore.tryReserve("co_1", creditTypeId, 300)).toBe(700);
+        for (let i = 0; i < 3; i++) {
+            await reservations.add(
+                makeReservation({ creditTypeId, creditsReserved: 100, expiresAt: new Date(Date.now() - 1) }),
+            );
+        }
+        expect(await reservations.reservedCredits("co_1", creditTypeId)).toBe(300);
+
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(3);
+        expect((await leaseStore.get("co_1", creditTypeId))?.localRemainingCredits).toBe(1_000);
+        expect(await reservations.size()).toBe(0);
+        expect(await reservations.reservedCredits("co_1", creditTypeId)).toBe(0);
+        reservations.stop();
+    });
+});

--- a/tests/unit/credits/check-and-track.test.ts
+++ b/tests/unit/credits/check-and-track.test.ts
@@ -1,0 +1,1219 @@
+import { SchematicClient } from "../../../src/wrapper";
+
+const mockCheckFlag = jest.fn();
+const mockAcquireCreditLease = jest.fn();
+const mockExtendCreditLease = jest.fn();
+const mockReleaseCreditLease = jest.fn();
+
+jest.mock("../../../src/Client", () => {
+    class MockBaseClient {
+        features = {
+            checkFlag: mockCheckFlag,
+            checkFlags: jest.fn().mockResolvedValue({ data: { flags: [] } }),
+        };
+        credits = {
+            acquireCreditLease: mockAcquireCreditLease,
+            extendCreditLease: mockExtendCreditLease,
+            releaseCreditLease: mockReleaseCreditLease,
+        };
+        events = {};
+    }
+    return { SchematicClient: MockBaseClient };
+});
+
+const mockEventBufferPush = jest.fn();
+jest.mock("../../../src/events", () => ({
+    EventBuffer: jest.fn().mockImplementation(() => ({
+        push: mockEventBufferPush,
+        flush: jest.fn().mockResolvedValue(undefined),
+        stop: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+// Stub DataStreamClient to a fixed shape — we manually wire its methods so
+// the lease path has everything it needs without spinning up a websocket.
+const mockDataStream = {
+    start: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn(),
+    isConnected: jest.fn().mockReturnValue(true),
+    checkFlag: jest.fn(),
+    updateCompanyMetrics: jest.fn().mockResolvedValue(undefined),
+    getFlag: jest.fn(),
+    getCachedCompany: jest.fn(),
+    getCompany: jest.fn(),
+    getCachedUser: jest.fn().mockResolvedValue(null),
+    getUser: jest.fn(),
+    getRulesEngine: jest.fn(),
+};
+
+jest.mock("../../../src/datastream", () => ({
+    DataStreamClient: jest.fn().mockImplementation(() => mockDataStream),
+}));
+
+// Stub rules engine
+const mockRulesEngine = {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    isInitialized: jest.fn().mockReturnValue(true),
+    checkFlag: jest.fn(),
+    checkFlagWithOptions: jest.fn(),
+    getVersionKey: jest.fn().mockReturnValue("1"),
+};
+jest.mock("../../../src/rules-engine", () => ({
+    RulesEngineClient: jest.fn().mockImplementation(() => mockRulesEngine),
+}));
+
+mockDataStream.getRulesEngine.mockReturnValue(mockRulesEngine);
+
+const flag = {
+    accountId: "acct",
+    defaultValue: false,
+    environmentId: "env",
+    id: "flag_1",
+    key: "inference",
+    rules: [
+        {
+            accountId: "acct",
+            conditionGroups: [],
+            conditions: [
+                {
+                    accountId: "acct",
+                    conditionType: "credit",
+                    consumptionRate: 10,
+                    creditId: "bilcr_inference",
+                    environmentId: "env",
+                    eventSubtype: "inference_tokens",
+                    id: "cond_1",
+                    operator: "gte",
+                    resourceIds: [],
+                    traitValue: "0",
+                },
+            ],
+            environmentId: "env",
+            id: "rule_1",
+            name: "credit gate",
+            priority: 1,
+            ruleType: "standard",
+            value: true,
+        },
+    ],
+};
+
+// Build a single-condition credit rule for a given credit type. Used to
+// assemble flags that meter one feature across multiple credit types.
+function makeCreditRule(id: string, creditId: string, consumptionRate: number) {
+    return {
+        accountId: "acct",
+        conditionGroups: [],
+        conditions: [
+            {
+                accountId: "acct",
+                conditionType: "credit",
+                consumptionRate,
+                creditId,
+                environmentId: "env",
+                eventSubtype: "inference_tokens",
+                id: `cond_${creditId}`,
+                operator: "gte",
+                resourceIds: [],
+                traitValue: "0",
+            },
+        ],
+        environmentId: "env",
+        id,
+        name: id,
+        priority: 1,
+        ruleType: "standard",
+        value: true,
+    };
+}
+
+const company = {
+    id: "co_1",
+    accountId: "acct",
+    environmentId: "env",
+    keys: { id: "co_1" },
+    metrics: [],
+    creditBalances: { bilcr_inference: 5000 },
+    planIds: [],
+    planVersionIds: [],
+    billingProductIds: [],
+    subscription: null,
+    traits: [],
+    rules: [],
+};
+
+function configureSuccessfulAcquire() {
+    mockAcquireCreditLease.mockResolvedValue({
+        data: {
+            id: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "bilcr_inference",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 5 * 60_000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        params: {},
+    });
+}
+
+function configureFailingAcquire() {
+    mockAcquireCreditLease.mockRejectedValue(new Error("lease 503"));
+}
+
+function configureDataStream() {
+    mockDataStream.getFlag.mockResolvedValue(flag);
+    mockDataStream.getCachedCompany.mockResolvedValue(company);
+    // The lease path resolves entities like a plain datastream check does:
+    // cache-first with a live WS fetch behind it (`getCompany`/`getUser`).
+    mockDataStream.getCompany.mockResolvedValue(company);
+}
+
+function makeClient() {
+    return new SchematicClient({
+        apiKey: "test-key",
+        useDataStream: true,
+        creditLeases: {
+            defaultLeaseDuration: 5 * 60_000,
+            defaultReservationTTL: 60_000,
+            defaultLeaseSize: 1000,
+            lowWaterMark: 0.25,
+            sweepIntervalMs: 60_000,
+        },
+        logger: {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        },
+    });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataStream.getRulesEngine.mockReturnValue(mockRulesEngine);
+    mockDataStream.isConnected.mockReturnValue(true);
+});
+
+describe("client.check (lease path)", () => {
+    it("issues a reservation when the engine says allowed", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+            entitlement: {
+                featureId: "feat",
+                featureKey: "inference",
+                valueType: "credit_burndown",
+                creditId: "bilcr_inference",
+                creditTotal: 1000,
+                creditUsed: 0,
+                creditRemaining: 1000,
+            },
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeDefined();
+        expect(result.reservation?.creditsReserved).toBe(500);
+        expect(result.reservation?.consumptionRate).toBe(10);
+        expect(result.reservation?.quantityReserved).toBe(50);
+        expect(mockAcquireCreditLease).toHaveBeenCalledTimes(1);
+        // Substituted balance flows into WASM: pre-reservation localRemaining = 1000.
+        const callArgs = mockRulesEngine.checkFlagWithOptions.mock.calls[0];
+        expect(callArgs[1].creditBalances.bilcr_inference).toBe(1000);
+        expect(callArgs[3]).toEqual({ eventUsage: { eventSubtype: "inference_tokens", quantity: 50 } });
+        await client.close();
+    });
+
+    it("leases the credit the company's matched plan uses when a flag mixes credit types", async () => {
+        // `inference` is entitled via two plans: a legacy USD-cents credit
+        // (declared first on the flag) and an AI-credits credit. The company is
+        // on the AI-credits plan, so the lease must target AI credits even
+        // though the USD condition appears first. The engine probe reports the
+        // matched plan's credit; we lease that, not the first-declared one.
+        const mixedCreditFlag = {
+            ...flag,
+            rules: [makeCreditRule("rule_usd", "bilcr_usd", 10), makeCreditRule("rule_ai", "bilcr_ai", 5)],
+        };
+        mockDataStream.getFlag.mockResolvedValue(mixedCreditFlag);
+        const mixedCompany = {
+            ...company,
+            creditBalances: { bilcr_usd: 0, bilcr_ai: 5000 },
+        };
+        mockDataStream.getCachedCompany.mockResolvedValue(mixedCompany);
+        mockDataStream.getCompany.mockResolvedValue(mixedCompany);
+        mockAcquireCreditLease.mockResolvedValue({
+            data: {
+                id: "lse_ai",
+                companyId: "co_1",
+                creditTypeId: "bilcr_ai",
+                grantedAmount: 1000,
+                expiresAt: new Date(Date.now() + 5 * 60_000),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            params: {},
+        });
+        // Probe + final eval both report the matched plan's credit (AI credits).
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched ai plan",
+            flagKey: "inference",
+            flagId: "flag_1",
+            entitlement: {
+                featureId: "feat",
+                featureKey: "inference",
+                valueType: "credit_burndown",
+                creditId: "bilcr_ai",
+                creditRemaining: 5000,
+            },
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        // Leased AI credits (the matched plan), not the first-declared USD credit.
+        expect(result.reservation?.creditTypeId).toBe("bilcr_ai");
+        expect(result.reservation?.consumptionRate).toBe(5);
+        expect(result.reservation?.creditsReserved).toBe(250);
+        expect(mockAcquireCreditLease).toHaveBeenCalledTimes(1);
+        expect(mockAcquireCreditLease.mock.calls[0][0].creditTypeId).toBe("bilcr_ai");
+        // One probe eval (raw balance) + one gating eval (substituted balance).
+        expect(mockRulesEngine.checkFlagWithOptions).toHaveBeenCalledTimes(2);
+        await client.close();
+    });
+
+    it("cancels the reservation when the allow comes from a different (non-credit) rule", async () => {
+        // The company is granted the feature by an override rule, not the
+        // credit-metered rule we reserved against. Billing the reservation
+        // would charge credits for usage the override grants for free — the
+        // hold must be cancelled and the allow returned without a handle.
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValueOnce({
+            value: true,
+            reason: "company override",
+            flagKey: "inference",
+            flagId: "flag_1",
+            ruleId: "rule_override",
+            ruleType: "company_override",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.value).toBe(true);
+        expect(result.reservation).toBeUndefined();
+
+        // The cancelled hold was refunded: a follow-up check that DOES match
+        // the credit rule sees the full lease balance (1000, not 1000-500)
+        // substituted into its evaluation.
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValueOnce({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+            ruleId: "rule_1",
+        });
+        const second = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+        expect(second.reservation?.creditsReserved).toBe(500);
+        const secondCallArgs = mockRulesEngine.checkFlagWithOptions.mock.calls[1];
+        expect(secondCallArgs[1].creditBalances.bilcr_inference).toBe(1000);
+        await client.close();
+    });
+
+    it("keeps the reservation when the engine reports the credit rule's ruleId", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+            ruleId: "rule_1",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeDefined();
+        await client.close();
+    });
+
+    it("returns allowed=false and refunds reservation when engine denies", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: false,
+            reason: "denied",
+            flagKey: "inference",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        await client.close();
+    });
+
+    it("fails closed when lease acquire errors and onAcquireFailure='fail-closed'", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-closed",
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        expect(mockRulesEngine.checkFlagWithOptions).not.toHaveBeenCalled();
+        await client.close();
+    });
+
+    it("defaults to fail-closed when onAcquireFailure is not specified", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        expect(mockRulesEngine.checkFlagWithOptions).not.toHaveBeenCalled();
+        await client.close();
+    });
+
+    it("respects explicit fail-open override on acquire failure, still evaluating the rules", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-open",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(result.err).toBe("lease_acquire_failed");
+        // Fail-open still runs the engine — with the credit balance substituted
+        // to an effectively unlimited value so only the credit gate is bypassed.
+        expect(mockRulesEngine.checkFlagWithOptions).toHaveBeenCalledTimes(1);
+        const callArgs = mockRulesEngine.checkFlagWithOptions.mock.calls[0];
+        expect(callArgs[1].creditBalances.bilcr_inference).toBe(Number.MAX_SAFE_INTEGER);
+        expect(callArgs[3]).toEqual({ eventUsage: { eventSubtype: "inference_tokens", quantity: 50 } });
+        await client.close();
+    });
+
+    it("fail-open still denies a company the rules do not entitle", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+        // The engine denies for a non-credit reason (e.g. no matching plan rule)
+        // even with the substituted unlimited balance.
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: false,
+            reason: "no matching rule",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-open",
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        expect(result.err).toBe("lease_acquire_failed");
+        await client.close();
+    });
+
+    it("fail-open falls back to a blanket allow when the fail-open evaluation itself errors", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockRejectedValue(new Error("wasm exploded"));
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-open",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        await client.close();
+    });
+
+    it("falls back to plain check when no preflight options are provided", async () => {
+        configureDataStream();
+        mockCheckFlag.mockResolvedValue({
+            data: { value: true, flag: "inference", reason: "match" },
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference");
+
+        expect(result.allowed).toBe(true);
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        await client.close();
+    });
+
+    it("threads preflight through the fallback when the lease path can't run", async () => {
+        configureDataStream();
+        // No cached flag → the lease path falls back to a plain check.
+        mockDataStream.getFlag.mockResolvedValue(null);
+        mockDataStream.checkFlag.mockResolvedValue({ value: true, reason: "match", flagKey: "inference" });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 25,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        // The plain check still gates on the post-call balance: the preflight
+        // rides along as eventUsage into the client-side evaluation instead of
+        // being silently dropped.
+        expect(mockDataStream.checkFlag).toHaveBeenCalledWith(
+            { company: { id: "co_1" } },
+            "inference",
+            expect.objectContaining({
+                eventUsage: { eventSubtype: "inference_tokens", quantity: 25 },
+            }),
+        );
+        await client.close();
+    });
+
+    it("short-circuits usage 0 to a plain check with no lease and no reservation", async () => {
+        // Zero usage means nothing to reserve — a 0-credit hold would be a pure
+        // no-op handle. The plain check still runs with the preflight threaded
+        // (usage: 0), so every rule evaluates normally.
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockDataStream.checkFlag.mockResolvedValue({ value: true, reason: "match", flagKey: "inference" });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 0,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        expect(mockDataStream.checkFlag).toHaveBeenCalledWith(
+            { company: { id: "co_1" } },
+            "inference",
+            expect.objectContaining({
+                eventUsage: { eventSubtype: "inference_tokens", quantity: 0 },
+            }),
+        );
+        await client.close();
+    });
+
+    it("threads preflight through a plain check when creditLeases is not configured", async () => {
+        mockDataStream.checkFlag.mockResolvedValue({ value: true, reason: "match", flagKey: "inference" });
+
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            useDataStream: true,
+            logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        });
+        // No eventSubtype: the quantity goes out as the generic `usage` knob.
+        const result = await client.check({ company: { id: "co_1" } }, "inference", { usage: 25 });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        expect(mockDataStream.checkFlag).toHaveBeenCalledWith(
+            { company: { id: "co_1" } },
+            "inference",
+            expect.objectContaining({ usage: 25 }),
+        );
+        await client.close();
+    });
+
+    it("falls back when neither the caller nor the condition supplies an event subtype", async () => {
+        // The reservation settles into a Track event named by the subtype; an
+        // empty event name would consume the reservation while billing
+        // nothing, so the lease path must decline to reserve.
+        configureSuccessfulAcquire();
+        configureDataStream();
+        const noSubtypeFlag = {
+            ...flag,
+            rules: [
+                {
+                    ...flag.rules[0],
+                    conditions: [{ ...flag.rules[0].conditions[0], eventSubtype: undefined }],
+                },
+            ],
+        };
+        mockDataStream.getFlag.mockResolvedValue(noSubtypeFlag);
+        mockDataStream.checkFlag.mockResolvedValue({ value: true, reason: "match", flagKey: "inference" });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", { usage: 50 });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        // The plain check still carries the usage preflight.
+        expect(mockDataStream.checkFlag).toHaveBeenCalledWith(
+            { company: { id: "co_1" } },
+            "inference",
+            expect.objectContaining({ usage: 50 }),
+        );
+        await client.close();
+    });
+
+    it("rejects NaN usage via the failure contract without touching the lease", async () => {
+        // Regression: an unguarded NaN debit poisons the lease balance into
+        // approving every subsequent reserve (`NaN < x` is always false).
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        const denied = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: Number.NaN,
+            eventSubtype: "inference_tokens",
+        });
+        expect(denied.allowed).toBe(false);
+        expect(denied.err).toBe("invalid_usage");
+        expect(denied.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+
+        // The lease path still gates correctly after the bad input: a valid
+        // check reserves against an unpoisoned balance.
+        const allowed = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+        expect(allowed.allowed).toBe(true);
+        expect(allowed.reservation?.creditsReserved).toBe(500);
+        await client.close();
+    });
+
+    it("resolves invalid usage through fail-open when configured", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: -10,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-open",
+        });
+        expect(result.allowed).toBe(true);
+        expect(result.err).toBe("invalid_usage");
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        await client.close();
+    });
+});
+
+describe("flag_check event reporting on the lease path", () => {
+    // Every lease-path resolution must enqueue a flag_check event, mirroring
+    // the plain checkFlag paths — otherwise lease-gated checks go dark in
+    // flag-check analytics and company last-seen.
+    function pushedFlagChecks() {
+        return mockEventBufferPush.mock.calls
+            .map((call) => call[0])
+            .filter((event) => event?.eventType === "flag_check");
+    }
+
+    it("enqueues a flag_check event when the engine allows", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+            ruleId: "rule_1",
+            companyId: "co_1",
+        });
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        const events = pushedFlagChecks();
+        expect(events).toHaveLength(1);
+        expect(events[0].body).toMatchObject({
+            flagKey: "inference",
+            value: true,
+            reason: "matched",
+            flagId: "flag_1",
+            ruleId: "rule_1",
+            companyId: "co_1",
+            reqCompany: { id: "co_1" },
+        });
+        await client.close();
+    });
+
+    it("enqueues a flag_check event when the engine denies", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: false,
+            reason: "denied",
+            flagKey: "inference",
+        });
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        const events = pushedFlagChecks();
+        expect(events).toHaveLength(1);
+        expect(events[0].body).toMatchObject({
+            flagKey: "inference",
+            value: false,
+            reason: "denied",
+            companyId: "co_1",
+        });
+        await client.close();
+    });
+
+    it("enqueues a flag_check event on a fail-closed acquire failure", async () => {
+        configureFailingAcquire();
+        configureDataStream();
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-closed",
+        });
+
+        const events = pushedFlagChecks();
+        expect(events).toHaveLength(1);
+        expect(events[0].body).toMatchObject({
+            flagKey: "inference",
+            value: false,
+            reason: "lease_acquire_failed",
+            error: "lease_acquire_failed",
+            companyId: "co_1",
+        });
+        await client.close();
+    });
+
+    it("enqueues exactly one flag_check event when the lease path delegates to the fallback", async () => {
+        // No cached flag → checkWithLease falls back to the plain check, which
+        // enqueues its own flag_check; the lease path must not add a second.
+        configureDataStream();
+        mockDataStream.getFlag.mockResolvedValue(null);
+        mockDataStream.checkFlag.mockResolvedValue({
+            value: true,
+            reason: "fallback",
+            flagKey: "inference",
+        });
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(pushedFlagChecks()).toHaveLength(1);
+        await client.close();
+    });
+});
+
+describe("client.prewarm (datastream resolution)", () => {
+    it("actively fetches a not-yet-cached company over the datastream before acquiring", async () => {
+        configureSuccessfulAcquire();
+        mockDataStream.getFlag.mockResolvedValue(flag);
+        // Not cached yet. prewarm actively fetches via getCompany (identify
+        // doesn't push the company into the cache on its own). Reject once to
+        // exercise the WS-connecting retry, then surface the company.
+        mockDataStream.getCachedCompany.mockResolvedValue(null);
+        mockDataStream.getCompany
+            .mockRejectedValueOnce(new Error("DataStream client is not connected"))
+            .mockResolvedValue(company);
+
+        const client = makeClient();
+        await client.prewarm({ company: { external_id: "ext-co-1" } }, ["bilcr_inference"]);
+
+        expect(mockDataStream.getCompany).toHaveBeenCalledWith({ external_id: "ext-co-1" });
+        expect(mockAcquireCreditLease).toHaveBeenCalledTimes(1);
+        expect(mockAcquireCreditLease).toHaveBeenCalledWith(
+            expect.objectContaining({ companyId: "co_1", creditTypeId: "bilcr_inference" }),
+            undefined,
+        );
+        await client.close();
+    });
+
+    it("gives up after prewarmResolveTimeoutMs without acquiring", async () => {
+        configureSuccessfulAcquire();
+        mockDataStream.getFlag.mockResolvedValue(flag);
+        mockDataStream.getCachedCompany.mockResolvedValue(null);
+        // Company never surfaces over the datastream.
+        mockDataStream.getCompany.mockRejectedValue(new Error("DataStream client is not connected"));
+
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            useDataStream: true,
+            creditLeases: {
+                defaultLeaseSize: 1000,
+                sweepIntervalMs: 60_000,
+                prewarmResolveTimeoutMs: 250,
+            },
+            logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        });
+        await client.prewarm({ company: { external_id: "ext-co-missing" } }, ["bilcr_inference"]);
+
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        await client.close();
+    });
+});
+
+describe("client.trackWithReservation", () => {
+    it("refunds unused credits and emits a Track event with actual quantity", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        const res = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+        if (!res.reservation) throw new Error("expected reservation");
+
+        // Local balance after reservation: 1000 - 500 = 500
+        await client.trackWithReservation(res.reservation, 20);
+
+        // Track event was enqueued with actualQuantity
+        const pushed = mockEventBufferPush.mock.calls.find((call) => call[0]?.eventType === "track");
+        expect(pushed).toBeDefined();
+        expect(pushed?.[0].body.event).toBe("inference_tokens");
+        expect(pushed?.[0].body.quantity).toBe(20);
+        expect(pushed?.[0].body.company).toEqual({ id: "co_1" });
+        await client.close();
+    });
+
+    it("emits a recovery Track keyed for idempotent dedupe when the reservation is gone before track", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            useDataStream: true,
+            creditLeases: { defaultLeaseSize: 1000, sweepIntervalMs: 60_000 },
+            logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        });
+        const reservation = {
+            id: "missing",
+            leaseId: "lse_x",
+            companyId: "co_1",
+            creditTypeId: "bilcr_inference",
+            eventSubtype: "inference_tokens",
+            quantityReserved: 10,
+            creditsReserved: 100,
+            consumptionRate: 10,
+            expiresAt: new Date(Date.now() + 60_000),
+            evalCtx: { company: { id: "co_1" } },
+        };
+
+        // Reservation is gone from the store (swept after TTL), but the work
+        // completed — we still owe the server a Track so the usage is billed.
+        await client.trackWithReservation(reservation, 5);
+        const trackCalls = () => mockEventBufferPush.mock.calls.filter((call) => call[0]?.eventType === "track");
+        expect(trackCalls()).toHaveLength(1);
+        const recovery = trackCalls()[0][0];
+        expect(recovery.body.event).toBe("inference_tokens");
+        expect(recovery.body.quantity).toBe(5);
+        expect(recovery.body.leaseId).toBe("lse_x");
+        // The Track carries a deterministic idempotency key derived from the
+        // reservation id, so the server dedupes duplicate/recovery emits.
+        expect(recovery.idempotencyKey).toBe("lease-reservation:missing");
+
+        // A second call re-emits with the SAME key — the SDK relies on the
+        // server's (account, env, event_type, key) dedupe to collapse them to
+        // one billed event, rather than suppressing client-side (which wouldn't
+        // hold across pods or restarts).
+        await client.trackWithReservation(reservation, 5);
+        const calls = trackCalls();
+        expect(calls).toHaveLength(2);
+        expect(calls[1][0].idempotencyKey).toBe("lease-reservation:missing");
+        await client.close();
+    });
+
+    it("keys the normal settle Track with the reservation id too", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+        const client = makeClient();
+        const res = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+        if (!res.reservation) throw new Error("expected reservation");
+
+        await client.trackWithReservation(res.reservation, 20);
+        const pushed = mockEventBufferPush.mock.calls.find((call) => call[0]?.eventType === "track");
+        expect(pushed?.[0].idempotencyKey).toBe(`lease-reservation:${res.reservation.id}`);
+        await client.close();
+    });
+
+    it("rejects a non-finite or negative actualQuantity without touching the store or billing", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+        const client = makeClient();
+        const res = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+        if (!res.reservation) throw new Error("expected reservation");
+
+        // Mirrors the check-path usage guard: a NaN settle would claim the
+        // reservation with no refund and serialize `quantity: null` into the
+        // billing event; negative would bill negative usage.
+        for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -5]) {
+            await client.trackWithReservation(res.reservation, bad);
+        }
+        expect(mockEventBufferPush.mock.calls.filter((call) => call[0]?.eventType === "track")).toHaveLength(0);
+
+        // The reservation was left untouched — a later valid settle still
+        // claims it and bills normally.
+        await client.trackWithReservation(res.reservation, 20);
+        const pushed2 = mockEventBufferPush.mock.calls.find((call) => call[0]?.eventType === "track");
+        expect(pushed2?.[0].body.quantity).toBe(20);
+        await client.close();
+    });
+});
+
+describe("evalCtx user resolution on the lease path", () => {
+    const user = {
+        id: "user_1",
+        accountId: "acct",
+        environmentId: "env",
+        keys: { id: "user_1" },
+        traits: [],
+        rules: [],
+    };
+
+    it("fetches the user over the datastream and evaluates with it", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockDataStream.getUser.mockResolvedValue(user);
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" }, user: { id: "user_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(mockDataStream.getUser).toHaveBeenCalledWith({ id: "user_1" });
+        // The resolved user is threaded into the gating eval — user-targeted
+        // rules and overrides apply on the lease path.
+        const callArgs = mockRulesEngine.checkFlagWithOptions.mock.calls[0];
+        expect(callArgs[2]).toBe(user);
+        await client.close();
+    });
+
+    it("falls back to a plain check when the user cannot be resolved", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockDataStream.getUser.mockRejectedValue(new Error("DataStream client is not connected"));
+        mockDataStream.checkFlag.mockResolvedValue({
+            value: true,
+            reason: "fallback",
+            flagKey: "inference",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" }, user: { id: "user_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        // Evaluating with a silently-dropped user could mis-gate — fall back
+        // to the plain check instead, which never reserves.
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        await client.close();
+    });
+
+    it("falls back to a plain check when the company cannot be resolved", async () => {
+        configureSuccessfulAcquire();
+        mockDataStream.getFlag.mockResolvedValue(flag);
+        mockDataStream.getCompany.mockRejectedValue(new Error("DataStream client is not connected"));
+        mockDataStream.checkFlag.mockResolvedValue({
+            value: true,
+            reason: "fallback",
+            flagKey: "inference",
+        });
+
+        const client = makeClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        expect(mockAcquireCreditLease).not.toHaveBeenCalled();
+        await client.close();
+    });
+});
+
+describe("store-failure containment (unreachable Redis backend)", () => {
+    function makeBrokenRedis() {
+        const err = new Error("redis down");
+        const reject = () => Promise.reject(err);
+        return {
+            get: reject,
+            set: reject,
+            setEx: reject,
+            del: reject,
+            // eslint-disable-next-line require-yield
+            scanIterator: async function* () {
+                throw err;
+            },
+            hSet: reject,
+            hGet: reject,
+            hGetAll: reject,
+            hDel: reject,
+            zAdd: reject,
+            zRangeByScore: reject,
+            zRem: reject,
+            zCard: reject,
+            eval: reject,
+            pExpireAt: reject,
+            // biome-ignore lint/suspicious/noExplicitAny: test stub
+        } as any;
+    }
+
+    function makeRedisBackedClient() {
+        return new SchematicClient({
+            apiKey: "test-key",
+            useDataStream: true,
+            creditLeases: {
+                defaultLeaseSize: 1000,
+                sweepIntervalMs: 60_000,
+                redisClient: makeBrokenRedis(),
+            },
+            logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        });
+    }
+
+    it("check() resolves fail-closed instead of rejecting when the store is down", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+
+        const client = makeRedisBackedClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        expect(result.err).toBeDefined();
+        await client.close();
+    });
+
+    it("check() honors fail-open (rules still evaluated) when the store is down", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeRedisBackedClient();
+        const result = await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            onAcquireFailure: "fail-open",
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        const callArgs = mockRulesEngine.checkFlagWithOptions.mock.calls[0];
+        expect(callArgs[1].creditBalances.bilcr_inference).toBe(Number.MAX_SAFE_INTEGER);
+        await client.close();
+    });
+
+    it("trackWithReservation still emits the billing Track when the local settle fails", async () => {
+        configureDataStream();
+        const client = makeRedisBackedClient();
+        const reservation = {
+            id: "res_orphan",
+            leaseId: "lse_x",
+            companyId: "co_1",
+            creditTypeId: "bilcr_inference",
+            eventSubtype: "inference_tokens",
+            quantityReserved: 10,
+            creditsReserved: 100,
+            consumptionRate: 10,
+            expiresAt: new Date(Date.now() + 60_000),
+            evalCtx: { company: { id: "co_1" } },
+        };
+
+        // Must not throw, and must still bill the usage.
+        await client.trackWithReservation(reservation, 7);
+
+        const pushed = mockEventBufferPush.mock.calls.find((call) => call[0]?.eventType === "track");
+        expect(pushed).toBeDefined();
+        expect(pushed?.[0].body.quantity).toBe(7);
+        expect(pushed?.[0].body.leaseId).toBe("lse_x");
+        expect(pushed?.[0].idempotencyKey).toBe("lease-reservation:res_orphan");
+        await client.close();
+    });
+});
+
+describe("close() lease release", () => {
+    it("releases this process's leases on close with the in-memory backend", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockReleaseCreditLease.mockResolvedValue({});
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", { usage: 50, eventSubtype: "inference_tokens" });
+        expect(mockReleaseCreditLease).not.toHaveBeenCalled();
+
+        await client.close();
+        // The in-memory store is exclusively this process's — releasing returns
+        // the unspent remainder to the company balance immediately.
+        expect(mockReleaseCreditLease).toHaveBeenCalledWith("lse_1", {});
+    });
+});
+
+describe("per-check timeout threading", () => {
+    it("threads timeoutMs to the lease acquire wire call", async () => {
+        configureSuccessfulAcquire();
+        configureDataStream();
+        mockRulesEngine.checkFlagWithOptions.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        await client.check({ company: { id: "co_1" } }, "inference", {
+            usage: 50,
+            eventSubtype: "inference_tokens",
+            timeoutMs: 2000,
+        });
+
+        expect(mockAcquireCreditLease).toHaveBeenCalledWith(expect.objectContaining({ companyId: "co_1" }), {
+            timeoutInSeconds: 2,
+        });
+        await client.close();
+    });
+});
+
+describe("checkFlag preflight forwarding", () => {
+    it("forwards preflight options to the datastream evaluation", async () => {
+        configureDataStream();
+        mockDataStream.checkFlag.mockResolvedValue({
+            value: true,
+            reason: "matched",
+            flagKey: "inference",
+            flagId: "flag_1",
+        });
+
+        const client = makeClient();
+        // Plain checkFlag with preflight knobs: no lease, no reservation — the
+        // options must still reach the local WASM evaluation (dry-run gate).
+        const options = {
+            usage: 5,
+            eventUsage: { eventSubtype: "inference_tokens", quantity: 5 },
+            creditCost: { bilcr_inference: 50 },
+        };
+        await client.checkFlag({ company: { id: "co_1" } }, "inference", options);
+
+        expect(mockDataStream.checkFlag).toHaveBeenCalledWith({ company: { id: "co_1" } }, "inference", options);
+        await client.close();
+    });
+});

--- a/tests/unit/credits/fake-redis.ts
+++ b/tests/unit/credits/fake-redis.ts
@@ -1,0 +1,271 @@
+import type { RedisClient } from "../../../src/cache/redis";
+
+/**
+ * In-memory implementation of the subset of the `RedisClient` interface used
+ * by `RedisLeaseStore` + `RedisReservationStore`. The `eval` method
+ * interprets the specific Lua scripts those stores send — it's not a generic
+ * Lua engine, just enough to exercise the atomic semantics in tests.
+ *
+ * Atomicity: the JS event loop is single-threaded and our Lua paths are all
+ * synchronous against the in-memory maps, so calling them from concurrent
+ * promises emulates real Redis Lua atomicity faithfully enough for these
+ * tests.
+ */
+export function makeFakeRedis(): RedisClient {
+    const strings = new Map<string, string>();
+    const hashes = new Map<string, Map<string, string>>();
+    const sets = new Map<string, Set<string>>();
+    const zsets = new Map<string, Map<string, number>>(); // member -> score
+    const expirations = new Map<string, number>(); // key -> epoch ms
+
+    const checkExpiry = (key: string): void => {
+        const exp = expirations.get(key);
+        if (exp !== undefined && exp <= Date.now()) {
+            strings.delete(key);
+            hashes.delete(key);
+            sets.delete(key);
+            zsets.delete(key);
+            expirations.delete(key);
+        }
+    };
+
+    const hgetAll = (key: string): Record<string, string> => {
+        checkExpiry(key);
+        const h = hashes.get(key);
+        if (!h) return {};
+        return Object.fromEntries(h.entries());
+    };
+
+    const hset = (key: string, field: string, value: string): void => {
+        if (!hashes.has(key)) hashes.set(key, new Map());
+        hashes.get(key)!.set(field, value);
+    };
+
+    const hget = (key: string, field: string): string | null => {
+        checkExpiry(key);
+        return hashes.get(key)?.get(field) ?? null;
+    };
+
+    const del = (key: string): void => {
+        strings.delete(key);
+        hashes.delete(key);
+        sets.delete(key);
+        zsets.delete(key);
+        expirations.delete(key);
+    };
+
+    const zadd = (key: string, score: number, member: string): void => {
+        if (!zsets.has(key)) zsets.set(key, new Map());
+        zsets.get(key)!.set(member, score);
+    };
+
+    const zrem = (key: string, member: string): void => {
+        zsets.get(key)?.delete(member);
+    };
+
+    const interpretScript = (script: string, keys: string[], args: string[]): unknown => {
+        const trimmed = script.trim();
+        // Every script below is single-key (KEYS[1] only) — mirroring the real
+        // stores, which avoid multi-key Lua so they stay Cluster-safe.
+        // Match by a stable substring per script.
+        if (
+            trimmed.includes("local existing_id = redis.call('HGET', KEYS[1], 'leaseId')") &&
+            trimmed.includes("if existing_id and existing_expiry > now then")
+        ) {
+            // REPLACE_SCRIPT — keeps any live lease (regardless of id).
+            // The real script reads `now` from the Redis server clock
+            // (redis.call('TIME')); we emulate that with the local clock since
+            // the fake is in-process.
+            const [leaseHashKey] = keys;
+            const [newId, newGranted, newExpiryStr, grace, companyId, creditTypeId] = args;
+            const newExpiry = Number(newExpiryStr);
+            const now = Date.now();
+            const existingId = hget(leaseHashKey, "leaseId");
+            const existingExpiry = Number(hget(leaseHashKey, "expiresAt") ?? "0");
+            if (existingId && existingExpiry > now) {
+                return 0;
+            }
+            del(leaseHashKey);
+            hset(leaseHashKey, "leaseId", newId);
+            hset(leaseHashKey, "companyId", companyId);
+            hset(leaseHashKey, "creditTypeId", creditTypeId);
+            hset(leaseHashKey, "grantedAmount", newGranted);
+            hset(leaseHashKey, "localRemainingCredits", newGranted);
+            hset(leaseHashKey, "expiresAt", newExpiryStr);
+            expirations.set(leaseHashKey, newExpiry + Number(grace));
+            return 1;
+        }
+        if (
+            trimmed.includes("local raw = redis.call('HGET', KEYS[1], 'localRemainingCredits')") &&
+            trimmed.includes("if remaining < requested then return false end")
+        ) {
+            // TRY_RESERVE_SCRIPT — `now` is the Redis server clock in the real
+            // script (redis.call('TIME')); emulated with the local clock here.
+            // Success returns the post-debit balance as a string (matching the
+            // real script's tostring()); failure returns nil (null here).
+            const [leaseHashKey] = keys;
+            const remainingRaw = hget(leaseHashKey, "localRemainingCredits");
+            if (remainingRaw === null) return null;
+            const expiry = Number(hget(leaseHashKey, "expiresAt") ?? "0");
+            const now = Date.now();
+            if (expiry <= now) return null;
+            const remaining = Number(remainingRaw);
+            const requested = Number(args[0]);
+            if (remaining < requested) return null;
+            const newRemaining = remaining - requested;
+            hset(leaseHashKey, "localRemainingCredits", String(newRemaining));
+            return String(newRemaining);
+        }
+        if (
+            trimmed.includes("local new_balance = remaining + refund") &&
+            trimmed.includes("if new_balance > granted then new_balance = granted end")
+        ) {
+            // REFUND_SCRIPT — ARGV[2] (when non-empty) pins the refund to a
+            // specific leaseId; a mismatch drops the refund.
+            const [leaseHashKey] = keys;
+            const rawRemaining = hget(leaseHashKey, "localRemainingCredits");
+            if (rawRemaining === null) return 0;
+            const requiredLease = args[1];
+            if (requiredLease && requiredLease !== "" && hget(leaseHashKey, "leaseId") !== requiredLease) {
+                return 0;
+            }
+            const remaining = Number(rawRemaining);
+            const granted = Number(hget(leaseHashKey, "grantedAmount") ?? "0");
+            const refund = Number(args[0]);
+            const newBalance = Math.min(remaining + refund, granted);
+            hset(leaseHashKey, "localRemainingCredits", String(newBalance));
+            return 1;
+        }
+        if (
+            trimmed.includes("local raw_granted = redis.call('HGET', KEYS[1], 'grantedAmount')") &&
+            trimmed.includes("local add = target - granted")
+        ) {
+            // EXTEND_SCRIPT — reconciles to the server-authoritative TOTAL
+            // (ARGV[1]); the credit delta is computed against the CURRENT
+            // stored total so concurrent extends converge instead of
+            // double-counting. Expiry only moves forward. ARGV[4] (when
+            // non-empty) pins the extend to a leaseId; a mismatch drops it.
+            const [leaseHashKey] = keys;
+            const rawGranted = hget(leaseHashKey, "grantedAmount");
+            if (rawGranted === null) return 0;
+            const requiredLease = args[3];
+            if (requiredLease && requiredLease !== "" && hget(leaseHashKey, "leaseId") !== requiredLease) {
+                return 0;
+            }
+            const granted = Number(rawGranted);
+            const target = Number(args[0]);
+            const add = target - granted;
+            if (add > 0) {
+                const remaining = Number(hget(leaseHashKey, "localRemainingCredits") ?? "0");
+                hset(leaseHashKey, "grantedAmount", String(target));
+                hset(leaseHashKey, "localRemainingCredits", String(remaining + add));
+            }
+            const newExpiry = Number(args[1]);
+            const grace = Number(args[2]);
+            const currentExpiry = Number(hget(leaseHashKey, "expiresAt") ?? "0");
+            if (newExpiry > currentExpiry) {
+                hset(leaseHashKey, "expiresAt", args[1]);
+                expirations.set(leaseHashKey, newExpiry + grace);
+            }
+            return 1;
+        }
+        if (
+            trimmed.includes("local raw = redis.call('HGETALL', KEYS[1])") &&
+            trimmed.includes("redis.call('DEL', KEYS[1])") &&
+            trimmed.includes("return raw")
+        ) {
+            // CLAIM_SCRIPT (reservation) — atomic read + delete, returns the
+            // flat [field, value, ...] array (or nil when already gone).
+            const [resHashKey] = keys;
+            const raw = hgetAll(resHashKey);
+            if (Object.keys(raw).length === 0) return null;
+            del(resHashKey);
+            const flat: string[] = [];
+            for (const [k, v] of Object.entries(raw)) {
+                flat.push(k, v);
+            }
+            return flat;
+        }
+        throw new Error(`fake-redis: unrecognized Lua script:\n${script}`);
+    };
+
+    return {
+        // Basic string ops (unused by lease stores but required by interface)
+        async get(key) {
+            checkExpiry(key);
+            return strings.get(key) ?? null;
+        },
+        async set(key, value) {
+            strings.set(key, String(value));
+        },
+        async setEx(key, seconds, value) {
+            strings.set(key, String(value));
+            expirations.set(key, Date.now() + seconds * 1000);
+        },
+        async del(keyOrKeys) {
+            const arr = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+            for (const k of arr) del(k);
+        },
+        async *scanIterator(_options) {
+            for (const k of [...strings.keys(), ...hashes.keys(), ...sets.keys(), ...zsets.keys()]) {
+                yield k;
+            }
+        },
+        // Hash ops
+        async hSet(key, field, value) {
+            if (typeof field === "object" && field !== null) {
+                for (const [f, v] of Object.entries(field)) {
+                    hset(key, f, String(v));
+                }
+                return;
+            }
+            hset(key, field, String(value));
+        },
+        async hGet(key, field) {
+            return hget(key, field) ?? undefined;
+        },
+        async hGetAll(key) {
+            return hgetAll(key);
+        },
+        async hDel(key, field) {
+            const fields = Array.isArray(field) ? field : [field];
+            const h = hashes.get(key);
+            if (!h) return;
+            for (const f of fields) h.delete(f);
+        },
+        // Sorted-set ops
+        async zAdd(key, members) {
+            const arr = Array.isArray(members) ? members : [members];
+            for (const m of arr) zadd(key, m.score, m.value);
+        },
+        async zRangeByScore(key, min, max, options) {
+            checkExpiry(key);
+            const z = zsets.get(key);
+            if (!z) return [];
+            const minN = min === "-inf" ? Number.NEGATIVE_INFINITY : Number(min);
+            const maxN = max === "+inf" ? Number.POSITIVE_INFINITY : Number(max);
+            const members = Array.from(z.entries())
+                .filter(([, score]) => score >= minN && score <= maxN)
+                .sort(([, a], [, b]) => a - b)
+                .map(([m]) => m);
+            if (options?.LIMIT) {
+                return members.slice(options.LIMIT.offset, options.LIMIT.offset + options.LIMIT.count);
+            }
+            return members;
+        },
+        async zRem(key, member) {
+            const members = Array.isArray(member) ? member : [member];
+            for (const m of members) zrem(key, m);
+        },
+        async eval(script, options) {
+            return interpretScript(script, options.keys, options.arguments);
+        },
+        async pExpireAt(key, timestamp) {
+            expirations.set(key, timestamp);
+        },
+        async zCard(key) {
+            checkExpiry(key);
+            return zsets.get(key)?.size ?? 0;
+        },
+    };
+}

--- a/tests/unit/credits/lease-manager.test.ts
+++ b/tests/unit/credits/lease-manager.test.ts
@@ -1,0 +1,677 @@
+import { CreditLeaseManager } from "../../../src/credits/lease-manager";
+import { LeaseStore } from "../../../src/credits/lease-store";
+import { RedisLeaseStore } from "../../../src/credits/redis-lease-store";
+import type { ILeaseStore } from "../../../src/credits/lease-store";
+import type { Logger } from "../../../src/logger";
+import { makeFakeRedis } from "./fake-redis";
+
+function makeLogger(): Logger {
+    return {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+}
+
+function makeManager(creditsClient: { [k: string]: jest.Mock }) {
+    const store = new LeaseStore();
+    const manager = new CreditLeaseManager({
+        // biome-ignore lint/suspicious/noExplicitAny: stubbed client
+        creditsClient: creditsClient as any,
+        leaseStore: store,
+        logger: makeLogger(),
+        config: {
+            defaultLeaseDuration: 5 * 60_000,
+            defaultReservationTTL: 60_000,
+            defaultLeaseSize: 1000,
+            lowWaterMark: 0.25,
+        },
+    });
+    return { manager, store };
+}
+
+describe("CreditLeaseManager", () => {
+    it("acquireIfNeeded calls acquireCreditLease and installs the lease", async () => {
+        const expiresAt = new Date(Date.now() + 5 * 60_000);
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+
+        const entry = await manager.acquireIfNeeded("co_1", "ct_1");
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+        expect(entry?.leaseId).toBe("lse_1");
+        expect(entry?.grantedAmount).toBe(1000);
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(1000);
+    });
+
+    it("acquireIfNeeded is single-flight for concurrent callers", async () => {
+        let resolve!: (v: unknown) => void;
+        const pending = new Promise((r) => (resolve = r));
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockReturnValue(pending),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager } = makeManager(creditsClient);
+
+        const p1 = manager.acquireIfNeeded("co_1", "ct_1");
+        const p2 = manager.acquireIfNeeded("co_1", "ct_1");
+        const p3 = manager.acquireIfNeeded("co_1", "ct_1");
+
+        resolve({
+            data: {
+                id: "lse_1",
+                companyId: "co_1",
+                creditTypeId: "ct_1",
+                grantedAmount: 1000,
+                expiresAt: new Date(Date.now() + 5 * 60_000),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            params: {},
+        });
+
+        await Promise.all([p1, p2, p3]);
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+    });
+
+    it("acquireIfNeeded reuses a live lease (no second wire call)", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager } = makeManager(creditsClient);
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+    });
+
+    it("acquireIfNeeded re-acquires over an expired slot, replacing it in place", async () => {
+        // No explicit drop happens inside acquireIfNeeded — `replace` overwrites
+        // the expired entry atomically. Seed an already-expired lease and verify
+        // the fresh one supplants it without a redundant-release call.
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_fresh",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        // Seed an already-expired lease in the slot.
+        await store.replace({
+            leaseId: "lse_stale",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() - 1),
+        });
+
+        const entry = await manager.acquireIfNeeded("co_1", "ct_1");
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+        // Fresh lease supplants the stale one in place, full balance restored.
+        expect(entry?.leaseId).toBe("lse_fresh");
+        expect(entry?.localRemainingCredits).toBe(1000);
+        expect(store.get("co_1", "ct_1")?.leaseId).toBe("lse_fresh");
+        // The redundant-lease release path must NOT fire: the slot was expired,
+        // so `replace` wrote (returned true) rather than keeping a live lease.
+        expect(creditsClient.releaseCreditLease).not.toHaveBeenCalled();
+    });
+
+    it("maybeExtendInBackground triggers extend when below low water mark", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 2000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        // Spend down to below 25%
+        await store.tryReserve("co_1", "ct_1", 800);
+        await manager.maybeExtendInBackground("co_1", "ct_1");
+        expect(creditsClient.extendCreditLease).toHaveBeenCalledTimes(1);
+        expect(store.get("co_1", "ct_1")?.grantedAmount).toBe(2000);
+    });
+
+    it("maybeExtendInBackground extends when requiredCredits exceeds local remaining even above watermark", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 2000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        // Spend a little — still well above the 25% watermark (900/1000 = 90%).
+        await store.tryReserve("co_1", "ct_1", 100);
+        // Without the hint, this would no-op (ratio > watermark).
+        await manager.maybeExtendInBackground("co_1", "ct_1");
+        expect(creditsClient.extendCreditLease).not.toHaveBeenCalled();
+        // Caller asks for 1500 credits worth — we only have 900 local, so extend.
+        await manager.maybeExtendInBackground("co_1", "ct_1", 1500);
+        expect(creditsClient.extendCreditLease).toHaveBeenCalledTimes(1);
+        expect(store.get("co_1", "ct_1")?.grantedAmount).toBe(2000);
+    });
+
+    it("sizes the extend to cover a request larger than the configured tranche", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 5100,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        await store.tryReserve("co_1", "ct_1", 100); // 900 remaining
+        // A single check needing 5000 credits: the shortfall (4100) exceeds the
+        // configured tranche (1000), so the extend must request the shortfall —
+        // a tranche-sized extend would leave the post-extend retry failing
+        // forever regardless of server balance.
+        await manager.maybeExtendInBackground("co_1", "ct_1", 5000);
+        expect(creditsClient.extendCreditLease).toHaveBeenCalledTimes(1);
+        const body = creditsClient.extendCreditLease.mock.calls[0][1];
+        expect(body.additionalAmount).toBe(4100);
+        // Local mirror reflects the server's new totals: 900 + 4100 = 5000.
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(5000);
+    });
+
+    it("maybeExtendInBackground refuses to extend an expired lease", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn(),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        // Expired lease, balance well below the watermark.
+        await store.replace({
+            leaseId: "lse_old",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() - 1_000),
+        });
+        const entry = await manager.maybeExtendInBackground("co_1", "ct_1", 1500);
+        expect(entry).toBeUndefined();
+        // The server treats an expired lease as released — the right move is a
+        // fresh acquire (next check's acquireIfNeeded), never an extend.
+        expect(creditsClient.extendCreditLease).not.toHaveBeenCalled();
+    });
+
+    it("acquireIfNeeded and maybeExtendInBackground report undefined instead of rejecting on store failures", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn(),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn(),
+        };
+        const brokenStore = {
+            get: jest.fn().mockRejectedValue(new Error("redis down")),
+            replace: jest.fn(),
+            extend: jest.fn(),
+            drop: jest.fn(),
+            tryReserve: jest.fn(),
+            refund: jest.fn(),
+        } as unknown as ILeaseStore;
+        const manager = new CreditLeaseManager({
+            // biome-ignore lint/suspicious/noExplicitAny: stubbed client
+            creditsClient: creditsClient as any,
+            leaseStore: brokenStore,
+            logger: makeLogger(),
+            config: {},
+        });
+        await expect(manager.acquireIfNeeded("co_1", "ct_1")).resolves.toBeUndefined();
+        // Often called fire-and-forget — a rejection would be unhandled.
+        await expect(manager.maybeExtendInBackground("co_1", "ct_1")).resolves.toBeUndefined();
+        expect(creditsClient.acquireCreditLease).not.toHaveBeenCalled();
+        expect(creditsClient.extendCreditLease).not.toHaveBeenCalled();
+    });
+
+    it("threads requestOptions to acquire and extend wire calls", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 2000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        const requestOptions = { timeoutInSeconds: 2 };
+        await manager.acquireIfNeeded("co_1", "ct_1", requestOptions);
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledWith(
+            expect.objectContaining({ companyId: "co_1" }),
+            requestOptions,
+        );
+        await store.tryReserve("co_1", "ct_1", 800);
+        await manager.maybeExtendInBackground("co_1", "ct_1", undefined, requestOptions);
+        expect(creditsClient.extendCreditLease).toHaveBeenCalledWith("lse_1", expect.anything(), requestOptions);
+    });
+
+    it("releaseAllLocalLeases releases live leases and skips expired ones", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn(),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn().mockResolvedValue({}),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        await store.replace({
+            leaseId: "lse_live",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.replace({
+            leaseId: "lse_expired",
+            companyId: "co_2",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() - 1_000),
+        });
+        await manager.releaseAllLocalLeases();
+        expect(creditsClient.releaseCreditLease).toHaveBeenCalledTimes(1);
+        expect(creditsClient.releaseCreditLease).toHaveBeenCalledWith("lse_live", {});
+        // Released lease is dropped locally; the expired one is left for lazy expiry.
+        expect(store.get("co_1", "ct_1")).toBeUndefined();
+    });
+
+    it("does not conflate concurrent acquire and extend on the same key", async () => {
+        // Pre-install a live lease with a sub-watermark balance so an extend
+        // is warranted. We then hold the extend mid-flight and fire an
+        // acquireIfNeeded against an *expired* slot for a different lease id —
+        // the two operations must not share inflight state.
+        let releaseExtend!: (v: unknown) => void;
+        const extendPending = new Promise((r) => (releaseExtend = r));
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_fresh",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn().mockReturnValue(extendPending),
+            releaseCreditLease: jest.fn(),
+        };
+        const { manager, store } = makeManager(creditsClient);
+        // Seed a live, debited lease so `maybeExtendInBackground` triggers an extend.
+        await store.replace({
+            leaseId: "lse_live",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 5 * 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 800); // 200 left → below 25% watermark
+
+        // Kick off the extend (will hang on extendPending).
+        const extendP = manager.maybeExtendInBackground("co_1", "ct_1");
+
+        // Drop the lease so acquire is needed, then call acquireIfNeeded —
+        // this must NOT receive the in-flight extend promise.
+        await store.drop("co_1", "ct_1");
+        const acquired = await manager.acquireIfNeeded("co_1", "ct_1");
+        expect(acquired?.leaseId).toBe("lse_fresh");
+        expect(creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+
+        // Let the extend resolve so we don't leak the pending promise.
+        releaseExtend({
+            data: {
+                id: "lse_live",
+                companyId: "co_1",
+                creditTypeId: "ct_1",
+                grantedAmount: 2000,
+                expiresAt: new Date(Date.now() + 5 * 60_000),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            params: {},
+        });
+        await extendP;
+    });
+
+    it("releases the redundant lease when it loses a concurrent cross-pod acquire race", async () => {
+        // Two managers share one backing store (mirrors two pods on one Redis).
+        // Both see an empty slot and acquire from the API in parallel; only one
+        // lease can win the slot, and the loser must release the lease it minted
+        // so it isn't left as an orphaned hold against the company balance.
+        const sharedStore: ILeaseStore = new RedisLeaseStore({ client: makeFakeRedis() });
+        const config = {
+            defaultLeaseDuration: 5 * 60_000,
+            defaultReservationTTL: 60_000,
+            defaultLeaseSize: 1000,
+            lowWaterMark: 0.25,
+        };
+        const mkManager = (leaseId: string) => {
+            const creditsClient = {
+                acquireCreditLease: jest.fn().mockResolvedValue({
+                    data: {
+                        id: leaseId,
+                        companyId: "co_1",
+                        creditTypeId: "ct_1",
+                        grantedAmount: 1000,
+                        expiresAt: new Date(Date.now() + 5 * 60_000),
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                    },
+                    params: {},
+                }),
+                extendCreditLease: jest.fn(),
+                releaseCreditLease: jest.fn().mockResolvedValue({ data: {}, params: {} }),
+            };
+            const manager = new CreditLeaseManager({
+                // biome-ignore lint/suspicious/noExplicitAny: stubbed client
+                creditsClient: creditsClient as any,
+                leaseStore: sharedStore,
+                logger: makeLogger(),
+                config,
+            });
+            return { manager, creditsClient };
+        };
+        const a = mkManager("lse_a");
+        const b = mkManager("lse_b");
+
+        const [ea, eb] = await Promise.all([
+            a.manager.acquireIfNeeded("co_1", "ct_1"),
+            b.manager.acquireIfNeeded("co_1", "ct_1"),
+        ]);
+
+        // Both raced to the API.
+        expect(a.creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+        expect(b.creditsClient.acquireCreditLease).toHaveBeenCalledTimes(1);
+
+        // Exactly one lease survives in the shared slot, and both managers see it.
+        const survivor = await sharedStore.get("co_1", "ct_1");
+        expect(survivor).toBeDefined();
+        expect(["lse_a", "lse_b"]).toContain(survivor!.leaseId);
+        expect(ea?.leaseId).toBe(survivor!.leaseId);
+        expect(eb?.leaseId).toBe(survivor!.leaseId);
+
+        // The loser released its redundant lease exactly once, across both.
+        const releaseCalls =
+            a.creditsClient.releaseCreditLease.mock.calls.length + b.creditsClient.releaseCreditLease.mock.calls.length;
+        expect(releaseCalls).toBe(1);
+        const loserId = survivor!.leaseId === "lse_a" ? "lse_b" : "lse_a";
+        const loser = survivor!.leaseId === "lse_a" ? b : a;
+        expect(loser.creditsClient.releaseCreditLease).toHaveBeenCalledWith(loserId, {});
+    });
+
+    it("does NOT release when a lost acquire race was handed the installed lease (idempotent server)", async () => {
+        // The server is idempotent for an active (company, creditType) slot:
+        // a racing acquire is handed back the SAME lease the sibling installed
+        // (`reused_active`). The loser's `replace` returns false, but there is
+        // nothing to release — releasing would mark the shared lease released
+        // server-side and refund its remainder while every pod keeps reserving
+        // against it locally.
+        const sharedStore: ILeaseStore = new RedisLeaseStore({ client: makeFakeRedis() });
+        const config = {
+            defaultLeaseDuration: 5 * 60_000,
+            defaultReservationTTL: 60_000,
+            defaultLeaseSize: 1000,
+            lowWaterMark: 0.25,
+        };
+        // Both managers' acquires resolve to the same server lease.
+        const mkManager = () => {
+            const creditsClient = {
+                acquireCreditLease: jest.fn().mockResolvedValue({
+                    data: {
+                        id: "lse_shared",
+                        companyId: "co_1",
+                        creditTypeId: "ct_1",
+                        grantedAmount: 1000,
+                        expiresAt: new Date(Date.now() + 5 * 60_000),
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                    },
+                    params: {},
+                }),
+                extendCreditLease: jest.fn(),
+                releaseCreditLease: jest.fn().mockResolvedValue({ data: {}, params: {} }),
+            };
+            const manager = new CreditLeaseManager({
+                // biome-ignore lint/suspicious/noExplicitAny: stubbed client
+                creditsClient: creditsClient as any,
+                leaseStore: sharedStore,
+                logger: makeLogger(),
+                config,
+            });
+            return { manager, creditsClient };
+        };
+        const a = mkManager();
+        const b = mkManager();
+
+        const [ea, eb] = await Promise.all([
+            a.manager.acquireIfNeeded("co_1", "ct_1"),
+            b.manager.acquireIfNeeded("co_1", "ct_1"),
+        ]);
+
+        // Both raced to the API and both came back holding the shared lease.
+        expect(ea?.leaseId).toBe("lse_shared");
+        expect(eb?.leaseId).toBe("lse_shared");
+        const survivor = await sharedStore.get("co_1", "ct_1");
+        expect(survivor?.leaseId).toBe("lse_shared");
+
+        // Neither manager released — the "redundant" lease IS the shared lease.
+        expect(a.creditsClient.releaseCreditLease).not.toHaveBeenCalled();
+        expect(b.creditsClient.releaseCreditLease).not.toHaveBeenCalled();
+    });
+
+    it("concurrent cross-pod extends reconcile to the server total instead of double-counting", async () => {
+        // Two managers share one backing store (mirrors two pods on one Redis).
+        // Per-process single-flight can't serialize their extends, so both
+        // wire calls go out against the same stale local read (granted=1000).
+        // The server applies them serially — totals 2000 then 3000 — and each
+        // pod reconciles to the TOTAL the server returned. With the old
+        // delta-apply, each pod would add its own stale-read delta
+        // (1000 + 2000) and mint 1000 phantom credits into the shared balance.
+        const sharedStore: ILeaseStore = new RedisLeaseStore({ client: makeFakeRedis() });
+        const config = {
+            defaultLeaseDuration: 5 * 60_000,
+            defaultReservationTTL: 60_000,
+            defaultLeaseSize: 1000,
+            lowWaterMark: 0.25,
+        };
+        const wireResponse = (grantedAmount: number) => ({
+            data: {
+                id: "lse_1",
+                companyId: "co_1",
+                creditTypeId: "ct_1",
+                grantedAmount,
+                expiresAt: new Date(Date.now() + 5 * 60_000),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            params: {},
+        });
+        const mkPod = (pendingExtend: Promise<unknown>) => {
+            const creditsClient = {
+                acquireCreditLease: jest.fn(),
+                extendCreditLease: jest.fn().mockReturnValue(pendingExtend),
+                releaseCreditLease: jest.fn(),
+            };
+            const manager = new CreditLeaseManager({
+                // biome-ignore lint/suspicious/noExplicitAny: stubbed client
+                creditsClient: creditsClient as any,
+                leaseStore: sharedStore,
+                logger: makeLogger(),
+                config,
+            });
+            return { manager, creditsClient };
+        };
+        let resolveA!: (v: unknown) => void;
+        let resolveB!: (v: unknown) => void;
+        const podA = mkPod(new Promise((r) => (resolveA = r)));
+        const podB = mkPod(new Promise((r) => (resolveB = r)));
+
+        await sharedStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 5 * 60_000),
+        });
+        // Spend down below the 25% watermark so both pods extend.
+        await sharedStore.tryReserve("co_1", "ct_1", 800);
+
+        // Both extends are issued before either wire call resolves, so both
+        // managers read the same stale granted=1000.
+        const extendA = podA.manager.maybeExtendInBackground("co_1", "ct_1");
+        const extendB = podB.manager.maybeExtendInBackground("co_1", "ct_1");
+        // Server lands B's extend first (total 2000), then A's (total 3000).
+        resolveB(wireResponse(2000));
+        resolveA(wireResponse(3000));
+        await Promise.all([extendA, extendB]);
+
+        expect(podA.creditsClient.extendCreditLease).toHaveBeenCalledTimes(1);
+        expect(podB.creditsClient.extendCreditLease).toHaveBeenCalledTimes(1);
+        const entry = await sharedStore.get("co_1", "ct_1");
+        // Authoritative totals: granted 3000; remaining 200 + 2000 = 2200.
+        expect(entry?.grantedAmount).toBe(3000);
+        expect(entry?.localRemainingCredits).toBe(2200);
+    });
+
+    it("does not release the lease on a normal uncontended acquire", async () => {
+        const creditsClient = {
+            acquireCreditLease: jest.fn().mockResolvedValue({
+                data: {
+                    id: "lse_1",
+                    companyId: "co_1",
+                    creditTypeId: "ct_1",
+                    grantedAmount: 1000,
+                    expiresAt: new Date(Date.now() + 5 * 60_000),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                params: {},
+            }),
+            extendCreditLease: jest.fn(),
+            releaseCreditLease: jest.fn().mockResolvedValue({ data: {}, params: {} }),
+        };
+        const { manager } = makeManager(creditsClient);
+        await manager.acquireIfNeeded("co_1", "ct_1");
+        expect(creditsClient.releaseCreditLease).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/credits/lease-store.test.ts
+++ b/tests/unit/credits/lease-store.test.ts
@@ -1,0 +1,252 @@
+import { LeaseStore } from "../../../src/credits/lease-store";
+
+describe("LeaseStore", () => {
+    let store: LeaseStore;
+
+    beforeEach(() => {
+        store = new LeaseStore();
+    });
+
+    it("replaces installs a lease with localRemaining=grantedAmount", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const entry = store.get("co_1", "ct_1");
+        expect(entry).toBeDefined();
+        expect(entry?.localRemainingCredits).toBe(100);
+        expect(entry?.grantedAmount).toBe(100);
+    });
+
+    it("tryReserve debits localRemaining and returns the post-debit balance on success", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const remaining = await store.tryReserve("co_1", "ct_1", 30);
+        expect(remaining).toBe(70);
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(70);
+    });
+
+    it("tryReserve returns null when insufficient and does not debit", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const remaining = await store.tryReserve("co_1", "ct_1", 150);
+        expect(remaining).toBeNull();
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(100);
+    });
+
+    it("tryReserve returns null against an expired lease and does not debit", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() - 1_000),
+        });
+        const remaining = await store.tryReserve("co_1", "ct_1", 10);
+        expect(remaining).toBeNull();
+        // Balance untouched — an expired lease is stale, the server has released it.
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(100);
+    });
+
+    it("tryReserve rejects NaN and negative debits without poisoning the balance", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        // NaN slips through `<` comparisons, so an unguarded debit would set
+        // the balance to NaN and approve every subsequent reserve.
+        expect(await store.tryReserve("co_1", "ct_1", Number.NaN)).toBeNull();
+        expect(await store.tryReserve("co_1", "ct_1", -10)).toBeNull();
+        expect(await store.tryReserve("co_1", "ct_1", Number.POSITIVE_INFINITY)).toBeNull();
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(100);
+        // The lease still gates correctly afterwards.
+        expect(await store.tryReserve("co_1", "ct_1", 30)).toBe(70);
+        expect(await store.tryReserve("co_1", "ct_1", 80)).toBeNull();
+    });
+
+    it("refund adds credits back, capped at grantedAmount", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 30);
+        await store.refund("co_1", "ct_1", 20);
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(90);
+        // Refunding past grantedAmount caps at grantedAmount
+        await store.refund("co_1", "ct_1", 9999);
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(100);
+    });
+
+    it("refund pinned to a stale leaseId is dropped; matching leaseId applies", async () => {
+        // Successor lease occupies the slot, partially debited.
+        await store.replace({
+            leaseId: "lse_b",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 50);
+        // A refund carved out of the previous lease must not inflate lse_b.
+        await store.refund("co_1", "ct_1", 30, "lse_a");
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(50);
+        // The same refund pinned to the current lease applies normally.
+        await store.refund("co_1", "ct_1", 30, "lse_b");
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(80);
+    });
+
+    it("concurrent tryReserves serialize and only succeed up to grantedAmount", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const results = await Promise.all([
+            store.tryReserve("co_1", "ct_1", 40),
+            store.tryReserve("co_1", "ct_1", 40),
+            store.tryReserve("co_1", "ct_1", 40),
+        ]);
+        const successes = results.filter((r) => r !== null).length;
+        expect(successes).toBe(2);
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(20);
+    });
+
+    it("extend reconciles to the server total, crediting the delta and moving expiry forward", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 10_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 30);
+        const newExpiry = new Date(Date.now() + 60_000);
+        await store.extend("co_1", "ct_1", 150, newExpiry);
+        const e = store.get("co_1", "ct_1");
+        expect(e?.grantedAmount).toBe(150);
+        expect(e?.localRemainingCredits).toBe(120);
+        expect(e?.expiresAt.getTime()).toBe(newExpiry.getTime());
+    });
+
+    it("a stale extend total is a no-op and never shortens the expiry", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 10_000),
+        });
+        // The larger server total lands first; a concurrent extend's smaller
+        // (already-superseded) total must apply as a no-op rather than
+        // re-crediting its delta, and must not pull the expiry backwards.
+        const farExpiry = new Date(Date.now() + 120_000);
+        await store.extend("co_1", "ct_1", 200, farExpiry);
+        await store.extend("co_1", "ct_1", 150, new Date(Date.now() + 60_000));
+        const e = store.get("co_1", "ct_1");
+        expect(e?.grantedAmount).toBe(200);
+        expect(e?.localRemainingCredits).toBe(200);
+        expect(e?.expiresAt.getTime()).toBe(farExpiry.getTime());
+    });
+
+    it("extend pinned to a stale leaseId is dropped; matching leaseId applies", async () => {
+        // Successor lease B occupies the slot (A expired mid-extend and was replaced).
+        await store.replace({
+            leaseId: "lse_B",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+
+        // A's extend lands late: pinned to lse_A, it must not credit B.
+        await store.extend("co_1", "ct_1", 150, new Date(Date.now() + 120_000), "lse_A");
+        let e = store.get("co_1", "ct_1");
+        expect(e?.grantedAmount).toBe(100);
+        expect(e?.localRemainingCredits).toBe(100);
+
+        // Pinned to the live lease, the extend applies.
+        await store.extend("co_1", "ct_1", 150, new Date(Date.now() + 120_000), "lse_B");
+        e = store.get("co_1", "ct_1");
+        expect(e?.grantedAmount).toBe(150);
+        expect(e?.localRemainingCredits).toBe(150);
+    });
+
+    it("drop removes the lease entry", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.drop("co_1", "ct_1");
+        expect(store.get("co_1", "ct_1")).toBeUndefined();
+    });
+
+    it("replace keeps an existing live lease (preserving its debited balance) and reports it did not write", async () => {
+        const wroteFirst = await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wroteFirst).toBe(true);
+        await store.tryReserve("co_1", "ct_1", 40);
+
+        // A racing acquire installs a different lease id while the first is
+        // still live — the existing debited balance must win.
+        const wroteSecond = await store.replace({
+            leaseId: "lse_2",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wroteSecond).toBe(false);
+        const entry = store.get("co_1", "ct_1");
+        expect(entry?.leaseId).toBe("lse_1");
+        expect(entry?.localRemainingCredits).toBe(60);
+    });
+
+    it("replace overwrites an expired lease and reports it wrote", async () => {
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() - 1_000),
+        });
+        const wrote = await store.replace({
+            leaseId: "lse_2",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wrote).toBe(true);
+        expect(store.get("co_1", "ct_1")?.leaseId).toBe("lse_2");
+        expect(store.get("co_1", "ct_1")?.localRemainingCredits).toBe(100);
+    });
+});

--- a/tests/unit/credits/redis-lease-store.test.ts
+++ b/tests/unit/credits/redis-lease-store.test.ts
@@ -1,0 +1,269 @@
+import { RedisLeaseStore } from "../../../src/credits/redis-lease-store";
+import { makeFakeRedis } from "./fake-redis";
+
+describe("RedisLeaseStore", () => {
+    it("replace installs a fresh lease, returns true", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        const wrote = await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wrote).toBe(true);
+        const entry = await store.get("co_1", "ct_1");
+        expect(entry?.leaseId).toBe("lse_1");
+        expect(entry?.localRemainingCredits).toBe(100);
+        expect(entry?.grantedAmount).toBe(100);
+    });
+
+    it("replace preserves debited state when the same live leaseId is rewritten", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 400);
+        // Simulate a second pod calling acquire and getting the same lease back.
+        const wrote = await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wrote).toBe(false);
+        const entry = await store.get("co_1", "ct_1");
+        expect(entry?.localRemainingCredits).toBe(600);
+    });
+
+    it("tryReserve atomically gates against the shared balance", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const results = await Promise.all([
+            store.tryReserve("co_1", "ct_1", 40),
+            store.tryReserve("co_1", "ct_1", 40),
+            store.tryReserve("co_1", "ct_1", 40),
+        ]);
+        // Two should succeed, one should fail (40 left after two debits).
+        // Successes return the post-debit balance; failures return null.
+        const successes = results.filter((r) => r !== null).sort((a, b) => (a ?? 0) - (b ?? 0));
+        expect(successes).toEqual([20, 60]);
+        const entry = await store.get("co_1", "ct_1");
+        expect(entry?.localRemainingCredits).toBe(20);
+    });
+
+    it("tryReserve rejects an expired-but-not-yet-evicted lease", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        // Expiry is in the past, but the TTL grace keeps the row alive in Redis.
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() - 1_000),
+        });
+        // Row still present (within grace window)...
+        expect(await store.get("co_1", "ct_1")).toBeDefined();
+        // ...but the expiry guard refuses to reserve against stale balance.
+        const result = await store.tryReserve("co_1", "ct_1", 10);
+        expect(result).toBeNull();
+        expect((await store.get("co_1", "ct_1"))?.localRemainingCredits).toBe(100);
+    });
+
+    it("tryReserve rejects NaN and negative debits before they reach the script", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        // `String(NaN)` parses back to nan in Lua and would poison the SHARED
+        // balance for every pod; the guard rejects it client-side.
+        expect(await store.tryReserve("co_1", "ct_1", Number.NaN)).toBeNull();
+        expect(await store.tryReserve("co_1", "ct_1", -10)).toBeNull();
+        expect((await store.get("co_1", "ct_1"))?.localRemainingCredits).toBe(100);
+        // The lease still gates correctly afterwards.
+        expect(await store.tryReserve("co_1", "ct_1", 30)).toBe(70);
+    });
+
+    it("refund caps at grantedAmount", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 30);
+        await store.refund("co_1", "ct_1", 9999);
+        const entry = await store.get("co_1", "ct_1");
+        expect(entry?.localRemainingCredits).toBe(100);
+    });
+
+    it("refund pinned to a stale leaseId is dropped; matching leaseId applies", async () => {
+        // Models a reservation taken from lease A whose slot has since been
+        // replaced by lease B: A's refund must not inflate B's balance.
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_b",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 50);
+        await store.refund("co_1", "ct_1", 30, "lse_a");
+        expect((await store.get("co_1", "ct_1"))?.localRemainingCredits).toBe(50);
+        await store.refund("co_1", "ct_1", 30, "lse_b");
+        expect((await store.get("co_1", "ct_1"))?.localRemainingCredits).toBe(80);
+    });
+
+    it("replace keeps a DIFFERENT live lease id, preserving its debited balance", async () => {
+        // Models two pods racing the first acquire for the same slot: the loser
+        // must not clobber the winner's already-debited balance.
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_winner",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.tryReserve("co_1", "ct_1", 400);
+        const wrote = await store.replace({
+            leaseId: "lse_loser",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(wrote).toBe(false);
+        const entry = await store.get("co_1", "ct_1");
+        expect(entry?.leaseId).toBe("lse_winner");
+        expect(entry?.localRemainingCredits).toBe(600);
+    });
+
+    it("extend honors defaultLeaseDurationMs option when newExpiresAt is omitted", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client, defaultLeaseDurationMs: 250 });
+        // Short initial expiry so the fallback (now + 250ms) is a *forward*
+        // move — expiry never moves backwards.
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 100),
+        });
+        const before = Date.now();
+        await store.extend("co_1", "ct_1", 150);
+        const entry = await store.get("co_1", "ct_1");
+        // Configured fallback is 250ms — expiry should land near `before + 250`.
+        const expiry = entry?.expiresAt.getTime() ?? 0;
+        expect(expiry).toBeGreaterThanOrEqual(before + 200);
+        expect(expiry).toBeLessThanOrEqual(before + 500);
+        expect(entry?.grantedAmount).toBe(150);
+    });
+
+    it("extend pinned to a stale leaseId is dropped; matching leaseId applies", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        // Successor lease B occupies the slot (A expired mid-extend and was replaced).
+        await store.replace({
+            leaseId: "lse_B",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+
+        // A's extend lands late: pinned to lse_A, it must not credit B.
+        await store.extend("co_1", "ct_1", 150, new Date(Date.now() + 120_000), "lse_A");
+        let entry = await store.get("co_1", "ct_1");
+        expect(entry?.grantedAmount).toBe(100);
+        expect(entry?.localRemainingCredits).toBe(100);
+
+        // Pinned to the live lease, the extend applies.
+        await store.extend("co_1", "ct_1", 150, new Date(Date.now() + 120_000), "lse_B");
+        entry = await store.get("co_1", "ct_1");
+        expect(entry?.grantedAmount).toBe(150);
+        expect(entry?.localRemainingCredits).toBe(150);
+    });
+
+    it("concurrent sibling-pod extends converge on the server total instead of double-counting", async () => {
+        const client = makeFakeRedis();
+        // Two pods sharing one Redis backend. Per-process single-flight can't
+        // serialize their extends, so both wire calls go out against the same
+        // stale local read (granted=100); the server lands B's first (total
+        // 150) then A's (total 200). Each pod applies the TOTAL the server
+        // returned — the slot must converge on 200, never 250 (the delta-apply
+        // double-count this regression test pins down).
+        const podA = new RedisLeaseStore({ client });
+        const podB = new RedisLeaseStore({ client });
+        await podA.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await podB.extend("co_1", "ct_1", 150, new Date(Date.now() + 90_000), "lse_1");
+        await podA.extend("co_1", "ct_1", 200, new Date(Date.now() + 120_000), "lse_1");
+        let entry = await podA.get("co_1", "ct_1");
+        expect(entry?.grantedAmount).toBe(200);
+        expect(entry?.localRemainingCredits).toBe(200);
+
+        // Out-of-order arrival: the larger total lands first, the superseded
+        // one applies as a no-op — and never pulls the expiry backwards.
+        await podA.replace({
+            leaseId: "lse_2",
+            companyId: "co_1",
+            creditTypeId: "ct_2",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        const farExpiry = new Date(Date.now() + 120_000);
+        await podA.extend("co_1", "ct_2", 200, farExpiry, "lse_2");
+        await podB.extend("co_1", "ct_2", 150, new Date(Date.now() + 90_000), "lse_2");
+        entry = await podA.get("co_1", "ct_2");
+        expect(entry?.grantedAmount).toBe(200);
+        expect(entry?.localRemainingCredits).toBe(200);
+        expect(entry?.expiresAt.getTime()).toBe(farExpiry.getTime());
+    });
+
+    it("drop removes the lease hash", async () => {
+        const client = makeFakeRedis();
+        const store = new RedisLeaseStore({ client });
+        await store.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await store.drop("co_1", "ct_1");
+        expect(await store.get("co_1", "ct_1")).toBeUndefined();
+    });
+});

--- a/tests/unit/credits/redis-reservation-store.test.ts
+++ b/tests/unit/credits/redis-reservation-store.test.ts
@@ -1,0 +1,297 @@
+import { RedisLeaseStore } from "../../../src/credits/redis-lease-store";
+import { RedisReservationStore } from "../../../src/credits/redis-reservation-store";
+import type { Reservation } from "../../../src/credits/types";
+import { makeFakeRedis } from "./fake-redis";
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+    return {
+        id: "res_1",
+        leaseId: "lse_1",
+        companyId: "co_1",
+        creditTypeId: "ct_1",
+        eventSubtype: "inference_tokens",
+        quantityReserved: 10,
+        creditsReserved: 100,
+        consumptionRate: 10,
+        expiresAt: new Date(Date.now() + 60_000),
+        evalCtx: { company: { id: "co_1" } },
+        ...overrides,
+    };
+}
+
+describe("RedisReservationStore", () => {
+    it("add round-trips through get and shows up in the expiry index", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+
+        const reservation = makeReservation();
+        await reservations.add(reservation);
+        const fetched = await reservations.get(reservation.id);
+        expect(fetched?.creditsReserved).toBe(100);
+        expect(await reservations.size()).toBe(1);
+        reservations.stop();
+    });
+
+    it("consume refunds unused credits atomically", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 100);
+        await reservations.add(makeReservation());
+        expect((await leaseStore.get("co_1", "ct_1"))?.localRemainingCredits).toBe(900);
+
+        const consumed = await reservations.consume("res_1", 30);
+        expect(consumed).toBe(30);
+        // Refunded 100-30=70
+        expect((await leaseStore.get("co_1", "ct_1"))?.localRemainingCredits).toBe(970);
+        expect(await reservations.get("res_1")).toBeUndefined();
+        reservations.stop();
+    });
+
+    it("sweepExpired returns expired reservations to the lease", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 100);
+        await reservations.add(makeReservation({ expiresAt: new Date(Date.now() - 1) }));
+
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(1);
+        expect((await leaseStore.get("co_1", "ct_1"))?.localRemainingCredits).toBe(1000);
+        expect(await reservations.get("res_1")).toBeUndefined();
+        reservations.stop();
+    });
+
+    it("does not refund a reservation from an old lease into a successor lease", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        // Reservation carved out of lse_1...
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 100);
+        await reservations.add(makeReservation({ expiresAt: new Date(Date.now() - 1) }));
+
+        // ...but the slot has since been replaced by lse_2, partially debited.
+        await leaseStore.drop("co_1", "ct_1");
+        await leaseStore.replace({
+            leaseId: "lse_2",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 200);
+
+        // The sweep claims the reservation but its refund (pinned to lse_1)
+        // must not inflate lse_2's balance.
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(1);
+        expect((await leaseStore.get("co_1", "ct_1"))?.localRemainingCredits).toBe(800);
+        expect(await reservations.get("res_1")).toBeUndefined();
+        reservations.stop();
+    });
+
+    it("reservedCredits sums open reservations and drops consumed ones", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 350);
+        await reservations.add(makeReservation({ id: "res_1", creditsReserved: 100 }));
+        await reservations.add(makeReservation({ id: "res_2", creditsReserved: 250 }));
+        // Different credit shouldn't count toward ct_1.
+        await reservations.add(makeReservation({ id: "res_3", creditTypeId: "ct_2", creditsReserved: 999 }));
+
+        expect(await reservations.reservedCredits("co_1", "ct_1")).toBe(350);
+        expect(await reservations.reservedCredits("co_1", "ct_2")).toBe(999);
+
+        await reservations.consume("res_1", 40);
+        expect(await reservations.reservedCredits("co_1", "ct_1")).toBe(250);
+        reservations.stop();
+    });
+
+    it("never issues a multi-key Lua EVAL (Cluster-safe: no CROSSSLOT)", async () => {
+        // A multi-key script whose keys hash to different slots raises CROSSSLOT
+        // on Redis Cluster. Guard that every EVAL the lease + reservation stores
+        // send touches exactly one key, across the full lifecycle.
+        const base = makeFakeRedis();
+        const evalKeyCounts: number[] = [];
+        const client = {
+            ...base,
+            eval: (script: string, options: { keys: string[]; arguments: string[] }) => {
+                evalKeyCounts.push(options.keys.length);
+                return base.eval(script, options);
+            },
+        } as typeof base;
+
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+
+        // Exercise every Lua path: replace, tryReserve, refund, extend (lease)
+        // and add, consume, sweep (reservation, whose refund delegates to the
+        // lease store's single-key REFUND).
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 200);
+        await leaseStore.refund("co_1", "ct_1", 50);
+        await leaseStore.extend("co_1", "ct_1", 100, new Date(Date.now() + 120_000));
+        await reservations.add(makeReservation({ id: "res_a", creditsReserved: 100 }));
+        await reservations.add(
+            makeReservation({ id: "res_b", creditsReserved: 80, expiresAt: new Date(Date.now() - 1) }),
+        );
+        await reservations.consume("res_a", 40);
+        await reservations.sweepExpired();
+
+        expect(evalKeyCounts.length).toBeGreaterThan(0);
+        expect(evalKeyCounts.every((n) => n === 1)).toBe(true);
+        reservations.stop();
+    });
+
+    it("sweep reconciles orphaned indexes when the reservation hash TTL-evicts before sweeping", async () => {
+        // Reproduces the failure mode where a sweeper goes silent (deploy/restart,
+        // event-loop starvation) long enough for Redis to evict the reservation
+        // hash via its TTL grace. Before the fix, the sweeper's `consume` would
+        // hit the hash-gone path and never clean the byExpiry set or the per-tenant
+        // `byCredit` hash — orphaning the index entry (unbounded zset growth) and
+        // permanently inflating `reservedCredits`.
+        jest.useFakeTimers();
+        try {
+            const t0 = new Date("2026-01-01T00:00:00Z").getTime();
+            jest.setSystemTime(t0);
+
+            const client = makeFakeRedis();
+            const leaseStore = new RedisLeaseStore({ client });
+            const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+            await leaseStore.replace({
+                leaseId: "lse_1",
+                companyId: "co_1",
+                creditTypeId: "ct_1",
+                grantedAmount: 1000,
+                expiresAt: new Date(t0 + 10 * 60_000),
+            });
+            await leaseStore.tryReserve("co_1", "ct_1", 100);
+            // Reservation expires in 1s; its hash is reaped 30s (RES_TTL_GRACE_MS)
+            // later. The lease lives well past both.
+            await reservations.add(makeReservation({ expiresAt: new Date(t0 + 1000) }));
+            expect(await reservations.size()).toBe(1);
+            expect(await reservations.reservedCredits("co_1", "ct_1")).toBe(100);
+
+            // Jump past the hash's TTL grace (but not the lease) so Redis would
+            // have evicted only the reservation hash.
+            jest.setSystemTime(t0 + 1000 + 30_000 + 1);
+
+            const swept = await reservations.sweepExpired();
+            // Nothing is "swept" in the refund sense — the hash is already gone, so
+            // the unspent slice is left for server-side lease expiry to reclaim.
+            expect(swept).toBe(0);
+            // But the orphaned secondary indexes are reconciled: no tombstone left
+            // in the expiry set, and reservedCredits no longer counts the evicted
+            // hold (this is what regressed before the fix).
+            expect(await reservations.size()).toBe(0);
+            expect(await reservations.reservedCredits("co_1", "ct_1")).toBe(0);
+            reservations.stop();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it("sweep drops an unparseable index member instead of wedging", async () => {
+        // Only `add` writes index members, so this shouldn't happen — but a
+        // member that doesn't decode must be removed from the set rather than
+        // re-read by every subsequent sweep.
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await client.zAdd("schematic:credit-reservations:byExpiry", { score: Date.now() - 1, value: "garbage" });
+
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(0);
+        expect(await reservations.size()).toBe(0);
+        reservations.stop();
+    });
+
+    it("sweep pages through a large backlog with LIMIT batches", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 100_000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        // More expired holds than one SWEEP_BATCH_SIZE page (256).
+        const count = 300;
+        await leaseStore.tryReserve("co_1", "ct_1", count);
+        for (let i = 0; i < count; i++) {
+            await reservations.add(
+                makeReservation({ id: `res_${i}`, creditsReserved: 1, expiresAt: new Date(Date.now() - 1) }),
+            );
+        }
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(count);
+        expect((await leaseStore.get("co_1", "ct_1"))?.localRemainingCredits).toBe(100_000);
+        expect(await reservations.size()).toBe(0);
+        expect(await reservations.reservedCredits("co_1", "ct_1")).toBe(0);
+        reservations.stop();
+    });
+
+    it("double-consume returns null on the second call", async () => {
+        const client = makeFakeRedis();
+        const leaseStore = new RedisLeaseStore({ client });
+        const reservations = new RedisReservationStore({ client, leaseStore, sweepIntervalMs: 60_000 });
+        await leaseStore.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leaseStore.tryReserve("co_1", "ct_1", 100);
+        await reservations.add(makeReservation());
+        await reservations.consume("res_1", 50);
+        const second = await reservations.consume("res_1", 10);
+        expect(second).toBeNull();
+        reservations.stop();
+    });
+});

--- a/tests/unit/credits/reservation-store.test.ts
+++ b/tests/unit/credits/reservation-store.test.ts
@@ -1,0 +1,135 @@
+import { LeaseStore } from "../../../src/credits/lease-store";
+import { ReservationStore } from "../../../src/credits/reservation-store";
+import type { Reservation } from "../../../src/credits/types";
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+    return {
+        id: "res_1",
+        leaseId: "lse_1",
+        companyId: "co_1",
+        creditTypeId: "ct_1",
+        eventSubtype: "inference_tokens",
+        quantityReserved: 10,
+        creditsReserved: 100,
+        consumptionRate: 10,
+        expiresAt: new Date(Date.now() + 60_000),
+        evalCtx: { company: { id: "co_1" } },
+        ...overrides,
+    };
+}
+
+describe("ReservationStore", () => {
+    let leases: LeaseStore;
+    let reservations: ReservationStore;
+
+    beforeEach(async () => {
+        leases = new LeaseStore();
+        reservations = new ReservationStore(leases, 50);
+        await leases.replace({
+            leaseId: "lse_1",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+    });
+
+    afterEach(() => {
+        reservations.stop();
+    });
+
+    it("consume refunds unused credits to the lease", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        const reservation = makeReservation();
+        reservations.add(reservation);
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(900);
+
+        const consumed = await reservations.consume(reservation.id, 30);
+        expect(consumed).toBe(30);
+        // Refunded 100 - 30 = 70
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(970);
+        expect(reservations.get(reservation.id)).toBeUndefined();
+    });
+
+    it("does not refund a reservation from an old lease into a successor lease", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        const reservation = makeReservation({ expiresAt: new Date(Date.now() - 1) });
+        reservations.add(reservation);
+
+        // Lease lse_1 expires; a successor lse_2 takes the slot, partially debited.
+        await leases.drop("co_1", "ct_1");
+        await leases.replace({
+            leaseId: "lse_2",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await leases.tryReserve("co_1", "ct_1", 200);
+
+        // Sweeping the expired lse_1 reservation must not inflate lse_2: its
+        // unspent slice was already returned to the company balance when lse_1
+        // expired server-side.
+        await reservations.sweepExpired();
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(800);
+        // Same for an explicit consume of a stale-lease reservation.
+        const reservation2 = makeReservation({ id: "res_2", expiresAt: new Date(Date.now() + 60_000) });
+        reservations.add(reservation2);
+        await reservations.consume(reservation2.id, 0);
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(800);
+    });
+
+    it("consume clamps credits consumed to creditsReserved", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        const reservation = makeReservation();
+        reservations.add(reservation);
+        const consumed = await reservations.consume(reservation.id, 999);
+        expect(consumed).toBe(100);
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(900);
+    });
+
+    it("consume returns null on missing reservation", async () => {
+        const result = await reservations.consume("nope", 10);
+        expect(result).toBeNull();
+    });
+
+    it("sweepExpired refunds expired reservations to the lease", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        const reservation = makeReservation({ expiresAt: new Date(Date.now() - 1) });
+        reservations.add(reservation);
+
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(1);
+        expect(reservations.get(reservation.id)).toBeUndefined();
+        expect(leases.get("co_1", "ct_1")?.localRemainingCredits).toBe(1000);
+    });
+
+    it("sweepExpired ignores non-expired reservations", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        reservations.add(makeReservation());
+        const swept = await reservations.sweepExpired();
+        expect(swept).toBe(0);
+        expect(reservations.size()).toBe(1);
+    });
+
+    it("reservedCredits sums open reservations for a (company, credit)", async () => {
+        reservations.add(makeReservation({ id: "res_1", creditsReserved: 100 }));
+        reservations.add(makeReservation({ id: "res_2", creditsReserved: 250 }));
+        // Different credit / company shouldn't count.
+        reservations.add(makeReservation({ id: "res_3", creditTypeId: "ct_2", creditsReserved: 999 }));
+        reservations.add(makeReservation({ id: "res_4", companyId: "co_2", creditsReserved: 999 }));
+
+        expect(reservations.reservedCredits("co_1", "ct_1")).toBe(350);
+        expect(reservations.reservedCredits("co_1", "ct_2")).toBe(999);
+        expect(reservations.reservedCredits("co_unknown", "ct_1")).toBe(0);
+    });
+
+    it("reservedCredits drops a reservation once it is consumed", async () => {
+        await leases.tryReserve("co_1", "ct_1", 100);
+        reservations.add(makeReservation());
+        expect(reservations.reservedCredits("co_1", "ct_1")).toBe(100);
+
+        await reservations.consume("res_1", 30);
+        expect(reservations.reservedCredits("co_1", "ct_1")).toBe(0);
+    });
+});

--- a/tests/unit/credits/wasm-credit-gate.test.ts
+++ b/tests/unit/credits/wasm-credit-gate.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Real-WASM tests for the credit-lease check path.
+ *
+ * Everything else in `tests/unit/credits` stubs the rules engine, so the
+ * contract that actually matters most — substituting the lease balance into
+ * the company's `creditBalances` and letting the WASM's `event_usage` gate
+ * decide allow/deny — is never exercised against the real engine. These tests
+ * load the bundled WASM (`src/wasm/rulesengine.js`) and drive a credit-balance
+ * flag end-to-end through `checkWithLease`, plus a direct rules-engine check, so
+ * that a drift in the snake_case option envelope (`event_usage`) or in the
+ * camelCase entity shape the SDK now feeds the engine would fail here instead of
+ * silently mis-gating in production.
+ */
+import type * as api from "../../../src/api";
+import type { DataStreamClient } from "../../../src/datastream";
+import type { Logger } from "../../../src/logger";
+import { RulesEngineClient } from "../../../src/rules-engine";
+import { LeaseStore } from "../../../src/credits/lease-store";
+import { ReservationStore } from "../../../src/credits/reservation-store";
+import { CreditLeaseManager } from "../../../src/credits/lease-manager";
+import { checkWithLease, type CreditCheckDeps } from "../../../src/credits/check";
+import type { CheckResult } from "../../../src/credits/types";
+
+const silentLogger: Logger = {
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+};
+
+const CREDIT_ID = "credit-1";
+const EVENT_SUBTYPE = "inference_tokens";
+
+// Credit condition (camelCase — the shape the datastream cache now holds after
+// the serializer canonicalizes wire payloads). `consumptionRate` 1 keeps
+// credits == quantity so the math is easy to follow.
+const creditCondition = {
+    id: "cond-credit",
+    accountId: "acct",
+    environmentId: "env",
+    conditionType: "credit",
+    operator: "gte",
+    resourceIds: [] as string[],
+    traitValue: "",
+    metricValue: 0,
+    creditId: CREDIT_ID,
+    consumptionRate: 1,
+    eventSubtype: EVENT_SUBTYPE,
+};
+
+// A `company`-membership condition we can flip to force the WASM to deny the
+// rule for reasons unrelated to the credit balance (so the lease reservation
+// gets refunded).
+function companyCondition(resourceIds: string[]) {
+    return {
+        id: "cond-company",
+        accountId: "acct",
+        environmentId: "env",
+        conditionType: "company",
+        operator: "eq",
+        resourceIds,
+        traitValue: "",
+        metricValue: 0,
+    };
+}
+
+function creditFlag(extraConditions: object[] = []): api.RulesengineFlag {
+    return {
+        id: "flag-infer",
+        accountId: "acct",
+        environmentId: "env",
+        key: "infer",
+        defaultValue: false,
+        rules: [
+            {
+                id: "rule-credit",
+                accountId: "acct",
+                environmentId: "env",
+                name: "Credit",
+                ruleType: "plan_entitlement",
+                priority: 100,
+                value: true,
+                conditions: [creditCondition, ...extraConditions],
+                conditionGroups: [],
+            },
+        ],
+    } as unknown as api.RulesengineFlag;
+}
+
+function company(creditBalance: number): api.RulesengineCompany {
+    return {
+        id: "co",
+        accountId: "acct",
+        environmentId: "env",
+        keys: {},
+        creditBalances: { [CREDIT_ID]: creditBalance },
+    } as unknown as api.RulesengineCompany;
+}
+
+// Minimal datastream stub: serves a fixed flag + company from "cache" and hands
+// back the REAL rules engine.
+function fakeDatastream(
+    engine: RulesEngineClient,
+    flag: api.RulesengineFlag,
+    co: api.RulesengineCompany,
+): DataStreamClient {
+    return {
+        getFlag: async () => flag,
+        getCachedCompany: async () => co,
+        getCachedUser: async () => null,
+        getCompany: async () => co,
+        getUser: async () => null,
+        getRulesEngine: () => engine,
+    } as unknown as DataStreamClient;
+}
+
+function makeDeps(
+    engine: RulesEngineClient,
+    flag: api.RulesengineFlag,
+    co: api.RulesengineCompany,
+    grantedAmount: number,
+): { deps: CreditCheckDeps; leaseStore: LeaseStore; reservations: ReservationStore } {
+    const leaseStore = new LeaseStore();
+    const reservations = new ReservationStore(leaseStore, 60_000);
+    const creditsClient = {
+        acquireCreditLease: jest.fn().mockResolvedValue({
+            data: {
+                id: "lse-1",
+                companyId: "co",
+                creditTypeId: CREDIT_ID,
+                grantedAmount,
+                expiresAt: new Date(Date.now() + 60_000),
+            },
+        }),
+        extendCreditLease: jest.fn(),
+        releaseCreditLease: jest.fn().mockResolvedValue({}),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const manager = new CreditLeaseManager({
+        creditsClient,
+        leaseStore,
+        logger: silentLogger,
+        config: { defaultLeaseSize: grantedAmount, defaultLeaseDuration: 60_000 },
+    });
+    const deps: CreditCheckDeps = {
+        leaseStore,
+        reservations,
+        manager,
+        datastream: fakeDatastream(engine, flag, co),
+        logger: silentLogger,
+        enqueueFlagCheckEvent: jest.fn(),
+    };
+    return { deps, leaseStore, reservations };
+}
+
+const evalCtx: api.CheckFlagRequestBody = { company: { id: "co" } };
+const failFallback = (): Promise<CheckResult> => {
+    throw new Error("fallback should not be reached on the lease path");
+};
+
+describe("credit-lease check against the real WASM engine", () => {
+    let engine: RulesEngineClient;
+
+    beforeAll(async () => {
+        engine = new RulesEngineClient();
+        await engine.initialize();
+    });
+
+    it("substitutes the lease balance and lets a within-balance usage through, issuing a reservation", async () => {
+        const { deps, leaseStore, reservations } = makeDeps(engine, creditFlag(), company(100), 10_000);
+
+        const result = await checkWithLease(
+            deps,
+            "infer",
+            evalCtx,
+            { usage: 50, eventSubtype: EVENT_SUBTYPE },
+            failFallback,
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(result.value).toBe(true);
+        expect(result.reservation).toBeDefined();
+        expect(result.reservation?.creditTypeId).toBe(CREDIT_ID);
+        expect(result.reservation?.creditsReserved).toBe(50);
+        // The 50-credit reservation stays debited from the lease's local view.
+        expect((await leaseStore.get("co", CREDIT_ID))?.localRemainingCredits).toBe(9_950);
+        expect(reservations.size()).toBe(1);
+    });
+
+    it("denies (and refunds the reservation) when the WASM rule fails for a non-credit reason", async () => {
+        // Credit balance is plentiful, but the company-membership condition
+        // excludes this company, so the WASM denies the rule. The reservation
+        // taken before the eval must be returned to the lease.
+        const flag = creditFlag([companyCondition(["some-other-company"])]);
+        const { deps, leaseStore, reservations } = makeDeps(engine, flag, company(10_000), 10_000);
+
+        const result = await checkWithLease(
+            deps,
+            "infer",
+            evalCtx,
+            { usage: 50, eventSubtype: EVENT_SUBTYPE },
+            failFallback,
+        );
+
+        expect(result.allowed).toBe(false);
+        expect(result.value).toBe(false);
+        expect(result.reservation).toBeUndefined();
+        // Reservation refunded: lease back to full, table empty.
+        expect((await leaseStore.get("co", CREDIT_ID))?.localRemainingCredits).toBe(10_000);
+        expect(reservations.size()).toBe(0);
+    });
+
+    it("cancels the reservation when the WASM allows via an override rule instead of the credit rule", async () => {
+        // The company is granted the feature by a company_override rule that
+        // outranks the credit-metered rule. The engine allows — but via a rule
+        // that doesn't meter this credit, so the reservation taken before the
+        // eval must be cancelled (no handle, nothing billed) rather than left
+        // to charge credits for usage the override grants for free.
+        const flag = creditFlag();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (flag.rules as any[]).unshift({
+            id: "rule-override",
+            accountId: "acct",
+            environmentId: "env",
+            name: "Override",
+            ruleType: "company_override",
+            priority: 1,
+            value: true,
+            conditions: [companyCondition(["co"])],
+            conditionGroups: [],
+        });
+        const { deps, leaseStore, reservations } = makeDeps(engine, flag, company(100), 10_000);
+
+        const result = await checkWithLease(
+            deps,
+            "infer",
+            evalCtx,
+            { usage: 50, eventSubtype: EVENT_SUBTYPE },
+            failFallback,
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(result.value).toBe(true);
+        expect(result.reservation).toBeUndefined();
+        // The hold was refunded: lease back to full, reservation table empty.
+        expect((await leaseStore.get("co", CREDIT_ID))?.localRemainingCredits).toBe(10_000);
+        expect(reservations.size()).toBe(0);
+    });
+
+    it("serializes CheckFlagOptions to the snake_case event_usage envelope the WASM gates on", async () => {
+        // Direct rules-engine check: prove the SDK's camelCase `eventUsage`
+        // option reaches the WASM as `event_usage` and gates exactly at the
+        // balance boundary. This is the contract `checkWithLease` leans on.
+        const flag = creditFlag();
+        const co = company(100);
+
+        const under = await engine.checkFlagWithOptions(flag, co, null, {
+            eventUsage: { eventSubtype: EVENT_SUBTYPE, quantity: 50 },
+        });
+        const over = await engine.checkFlagWithOptions(flag, co, null, {
+            eventUsage: { eventSubtype: EVENT_SUBTYPE, quantity: 150 },
+        });
+
+        expect(under.value).toBe(true);
+        expect(over.value).toBe(false);
+    });
+});

--- a/tests/unit/datastream/datastream-client.test.ts
+++ b/tests/unit/datastream/datastream-client.test.ts
@@ -40,11 +40,23 @@ jest.mock('../../../src/datastream/websocket-client', () => {
   };
 });
 
-// Mock RulesEngineClient so we can control what checkFlag returns
-const mockRulesEngineInstance = {
+// Mock RulesEngineClient so we can control what checkFlag returns.
+// The real client routes evaluateFlag through `checkFlagWithOptions`; mock
+// it to delegate to `checkFlag` so existing tests that stub `checkFlag` keep
+// working without per-test churn.
+const mockRulesEngineInstance: {
+  initialize: jest.Mock;
+  isInitialized: jest.Mock;
+  checkFlag: jest.Mock;
+  checkFlagWithOptions: jest.Mock;
+  getVersionKey: jest.Mock;
+} = {
   initialize: jest.fn().mockResolvedValue(undefined),
   isInitialized: jest.fn().mockReturnValue(false),
   checkFlag: jest.fn(),
+  checkFlagWithOptions: jest.fn((flag, company, user, _options) =>
+    mockRulesEngineInstance.checkFlag(flag, company, user),
+  ),
   getVersionKey: jest.fn().mockReturnValue('1'),
 };
 
@@ -129,6 +141,26 @@ describe('DataStreamClient', () => {
   test('should initialize with default options', () => {
     expect(client).toBeInstanceOf(DataStreamClient);
     expect(client.isConnected()).toBe(false);
+  });
+
+  test('should default baseURL to the standard API environment when omitted', async () => {
+    // Mirrors the REST client's default so `useDataStream: true` works
+    // without an explicit basePath (the WS layer maps api.* hosts to their
+    // datastream.* counterpart).
+    const clientWithoutBaseURL = new DataStreamClient({
+      apiKey: 'test-api-key',
+      logger: mockLogger,
+    });
+    try {
+      await clientWithoutBaseURL.start();
+      expect(DatastreamWSClient).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://api.schematichq.com' }),
+      );
+    } finally {
+      clientWithoutBaseURL.removeAllListeners();
+      clientWithoutBaseURL.close();
+      await new Promise(resolve => setImmediate(resolve));
+    }
   });
 
   test('should initialize with custom cache providers', () => {
@@ -786,6 +818,49 @@ describe('DataStreamClient', () => {
     
     // Restore original fetch
     global.fetch = originalFetch;
+  });
+
+  test('forwards preflight options to the rules engine in replicator mode', async () => {
+    // The replicator branch of checkFlag evaluates straight from cache without
+    // any WS fetching — assert the preflight envelope still reaches the
+    // engine's checkFlagWithOptions there, not just on the datastream path.
+    const flagCache = new LocalCache<Schematic.RulesengineFlag>();
+    // The external replicator normally populates this cache; seed it directly
+    // under the same key the client computes (`flags:<engine version>:<key>`).
+    await flagCache.set('flags:1:test-flag', asFlag(mockFlag));
+
+    const replicatorClient = new DataStreamClient({
+      ...options,
+      replicatorMode: true,
+      flagCache,
+    });
+
+    mockRulesEngineInstance.isInitialized.mockReturnValue(true);
+    mockRulesEngineInstance.checkFlag.mockResolvedValue({ value: true, reason: 'ok' });
+
+    const preflight = {
+      usage: 5,
+      eventUsage: { eventSubtype: 'inference_tokens', quantity: 5 },
+      creditCost: { bilcr_inference: 50 },
+    };
+    try {
+      const result = await replicatorClient.checkFlag({ company: { name: 'Test Company' } }, 'test-flag', preflight);
+
+      expect(result.value).toBe(true);
+      // Company/user aren't cached, so the replicator branch evaluates them as
+      // null — but the preflight options must be threaded through verbatim.
+      expect(mockRulesEngineInstance.checkFlagWithOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'flag-123' }),
+        null,
+        null,
+        preflight,
+      );
+    } finally {
+      mockRulesEngineInstance.isInitialized.mockReturnValue(false);
+      replicatorClient.removeAllListeners();
+      replicatorClient.close();
+      await new Promise(resolve => setImmediate(resolve));
+    }
   });
 
   test('should use rules engine version key for cache keys in non-replicator mode', async () => {

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -23,6 +23,7 @@ jest.mock("../../src/events", () => {
     return {
         EventBuffer: jest.fn().mockImplementation(() => ({
             push: jest.fn(),
+            flush: jest.fn().mockResolvedValue(undefined),
             stop: jest.fn().mockResolvedValue(undefined),
         })),
     };
@@ -81,10 +82,7 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
                 logger: mockLogger,
             });
 
-            const result = await client.checkFlag(
-                { company: { id: "comp-1" } },
-                "test-flag",
-            );
+            const result = await client.checkFlag({ company: { id: "comp-1" } }, "test-flag");
 
             expect(result).toBe(false);
 
@@ -101,10 +99,7 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
                 logger: mockLogger,
             });
 
-            const result = await client.checkFlag(
-                { company: { id: "comp-1" } },
-                "test-flag",
-            );
+            const result = await client.checkFlag({ company: { id: "comp-1" } }, "test-flag");
 
             expect(result).toBe(true);
 
@@ -134,14 +129,8 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
                 logger: mockLogger,
             });
 
-            await client.checkFlag(
-                { company: { id: "comp-1" } },
-                "test-flag",
-            );
-            await client.checkFlag(
-                { company: { id: "comp-2" } },
-                "test-flag",
-            );
+            await client.checkFlag({ company: { id: "comp-1" } }, "test-flag");
+            await client.checkFlag({ company: { id: "comp-2" } }, "test-flag");
 
             // Two different contexts should produce two cache get calls with different keys
             expect(mockCacheProvider.get).toHaveBeenCalledTimes(2);
@@ -170,14 +159,8 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
                 logger: mockLogger,
             });
 
-            const result1 = await client.checkFlag(
-                { company: { id: "comp-1" } },
-                "test-flag",
-            );
-            const result2 = await client.checkFlag(
-                { company: { id: "comp-1" } },
-                "test-flag",
-            );
+            const result1 = await client.checkFlag({ company: { id: "comp-1" } }, "test-flag");
+            const result2 = await client.checkFlag({ company: { id: "comp-1" } }, "test-flag");
 
             expect(result1).toBe(true);
             expect(result2).toBe(true);
@@ -188,7 +171,6 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
             await client.close();
         });
     });
-
     describe("event options", () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { EventBuffer } = require("../../src/events");
@@ -228,10 +210,7 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
         it("should thread identify idempotencyKey into the buffered event", async () => {
             const client = new SchematicClient({ apiKey: "test-api-key", logger: mockLogger });
 
-            await client.identify(
-                { keys: { id: "user-1" }, name: "Test User" },
-                { idempotencyKey: "dedupe-xyz" },
-            );
+            await client.identify({ keys: { id: "user-1" }, name: "Test User" }, { idempotencyKey: "dedupe-xyz" });
 
             const event = lastPushedEvent();
             expect(event.eventType).toBe("identify");
@@ -255,6 +234,158 @@ describe("SchematicClient wrapper - flag checking behavior", () => {
 
             await client.close();
         });
+    });
+
+    describe("identify with prewarm", () => {
+        it("forwards prewarm credit type ids to client.prewarm and flushes the buffer", async () => {
+            const client = new SchematicClient({
+                apiKey: "test-api-key",
+                cacheProviders: { flagChecks: [] },
+                logger: mockLogger,
+            });
+            const prewarmSpy = jest.spyOn(client, "prewarm").mockResolvedValue(undefined);
+            // Reach into the buffer mock to verify flush is triggered so the
+            // server picks up the identify event before prewarm starts polling.
+            // biome-ignore lint/suspicious/noExplicitAny: introspect mock
+            const flushMock = (client as any).eventBuffer.flush as jest.Mock;
+
+            await client.identify(
+                {
+                    keys: { id: "user-1" },
+                    company: { keys: { id: "comp-1" } },
+                },
+                { prewarm: ["credit-type-1", "credit-type-2"] },
+            );
+
+            // Yield once so the fire-and-forget prewarm resolves.
+            await new Promise((r) => setImmediate(r));
+
+            expect(flushMock).toHaveBeenCalledTimes(1);
+            expect(prewarmSpy).toHaveBeenCalledWith({ company: { id: "comp-1" }, user: { id: "user-1" } }, [
+                "credit-type-1",
+                "credit-type-2",
+            ]);
+
+            await client.close();
+        });
+
+        it("does not call prewarm or flush when options.prewarm is omitted", async () => {
+            const client = new SchematicClient({
+                apiKey: "test-api-key",
+                cacheProviders: { flagChecks: [] },
+                logger: mockLogger,
+            });
+            const prewarmSpy = jest.spyOn(client, "prewarm").mockResolvedValue(undefined);
+            // biome-ignore lint/suspicious/noExplicitAny: introspect mock
+            const flushMock = (client as any).eventBuffer.flush as jest.Mock;
+
+            await client.identify({
+                keys: { id: "user-1" },
+                company: { keys: { id: "comp-1" } },
+            });
+
+            await new Promise((r) => setImmediate(r));
+            expect(prewarmSpy).not.toHaveBeenCalled();
+            expect(flushMock).not.toHaveBeenCalled();
+
+            await client.close();
+        });
+    });
+});
+
+describe("SchematicClient wrapper - getCreditBalance lease awareness", () => {
+    const mockLogger = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+    };
+
+    const companyKeys = { id: "comp-1" };
+    const creditId = "credit-ai";
+
+    // Builds a client wired with a cached snapshot carrying `serverBalance`, a
+    // lease store returning `leaseEntry` (or undefined for "no lease"), and a
+    // reservation store summing to `reservedCredits`. All are private fields
+    // the wrapper reads in getCreditBalance.
+    const buildClient = (
+        serverBalance: number,
+        leaseEntry: { localRemainingCredits: number; expiresAt: Date } | undefined,
+        reservedCredits = 0,
+    ) => {
+        const client = new SchematicClient({ offline: true, logger: mockLogger });
+        (client as any).datastreamClient = {
+            getCachedCompany: jest.fn().mockResolvedValue({
+                id: "comp-internal-id",
+                creditBalances: { [creditId]: serverBalance },
+            }),
+            close: jest.fn(),
+        };
+        (client as any).leaseStore = {
+            get: jest.fn().mockResolvedValue(leaseEntry),
+        };
+        (client as any).reservations = {
+            reservedCredits: jest.fn().mockReturnValue(reservedCredits),
+            stop: jest.fn(),
+        };
+        return client;
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("reports a live lease's unspent local balance as reserved on top of remaining", async () => {
+        // remaining (B−L)=600, lease hold (L−spent)=900 ⇒ settled 1500.
+        const client = buildClient(600, {
+            localRemainingCredits: 900,
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+
+        const result = await client.getCreditBalance(companyKeys, creditId);
+
+        expect(result).toEqual({ remaining: 600, reserved: 900, settled: 1500 });
+        await client.close();
+    });
+
+    it("folds open reservations into reserved so an in-flight hold doesn't dip settled", async () => {
+        // A 1500-credit reservation has carved out of the lease's local
+        // balance (900 = 2400 granted − 1500 reserved). `reserved` reports the
+        // whole unsettled lease hold (lease remainder 900 + open reservation
+        // 1500 = 2400), so settled = 600 + 2400 = 3000 = B − spent (nothing
+        // settled yet) and stays put whether or not the hold is open.
+        const client = buildClient(600, { localRemainingCredits: 900, expiresAt: new Date(Date.now() + 60_000) }, 1500);
+
+        const result = await client.getCreditBalance(companyKeys, creditId);
+
+        expect(result).toEqual({ remaining: 600, reserved: 2400, settled: 3000 });
+        await client.close();
+    });
+
+    it("ignores an expired lease so the refunded hold isn't double-counted", async () => {
+        // Past expiresAt the server has swept and refunded the hold, so the
+        // whole balance already sits in `remaining`. Counting the dead hold too
+        // would report settled 23000 — the stale-overstated-badge bug. Any open
+        // reservation is ignored for the same reason.
+        const client = buildClient(
+            12_000,
+            { localRemainingCredits: 11_000, expiresAt: new Date(Date.now() - 1_000) },
+            500,
+        );
+
+        const result = await client.getCreditBalance(companyKeys, creditId);
+
+        expect(result).toEqual({ remaining: 12_000, reserved: 0, settled: 12_000 });
+        await client.close();
+    });
+
+    it("returns the server balance as remaining when no lease is held", async () => {
+        const client = buildClient(450, undefined);
+
+        const result = await client.getCreditBalance(companyKeys, creditId);
+
+        expect(result).toEqual({ remaining: 450, reserved: 0, settled: 450 });
+        await client.close();
     });
 });
 
@@ -320,5 +451,126 @@ describe("SchematicClient wrapper - logger configuration", () => {
         expect(consoleSpy.debug).not.toHaveBeenCalled();
 
         await client.close();
+    });
+});
+describe("SchematicClient wrapper - credit lease store backend selection", () => {
+    const mockLogger = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("reuses the DataStream Redis client for lease state when no creditLeases.redisClient is set", async () => {
+        const { makeFakeRedis } = await import("./credits/fake-redis");
+        const redisClient = makeFakeRedis();
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            logger: mockLogger,
+            creditLeases: {},
+            dataStream: { redisClient },
+        });
+        // The shared Redis backend must back leases automatically — no second
+        // client to wire up — so both stores are the Redis-backed variants.
+        expect((client as any).leaseStore?.constructor?.name).toBe("RedisLeaseStore");
+        expect((client as any).reservations?.constructor?.name).toBe("RedisReservationStore");
+        // No degrade warning when a shared backend is present.
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining("creditLeases is enabled without a shared Redis backend"),
+        );
+        (client as any).reservations?.stop?.();
+    });
+
+    it("falls back to in-memory stores and warns when no Redis backend is configured", async () => {
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            logger: mockLogger,
+            creditLeases: {},
+        });
+        expect((client as any).leaseStore?.constructor?.name).toBe("LeaseStore");
+        expect((client as any).reservations?.constructor?.name).toBe("ReservationStore");
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("creditLeases is enabled without a shared Redis backend"),
+        );
+        (client as any).reservations?.stop?.();
+    });
+
+    it("warns at construction when creditLeases is configured without DataStream", async () => {
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            logger: mockLogger,
+            creditLeases: {},
+        });
+        // Without DataStream, every check() silently falls back to a plain flag
+        // check with no credit gating — surface that once, loudly.
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("creditLeases is configured but DataStream is not enabled"),
+        );
+        (client as any).reservations?.stop?.();
+    });
+
+    it("does not warn about DataStream when it is enabled alongside creditLeases", async () => {
+        const { makeFakeRedis } = await import("./credits/fake-redis");
+        const redisClient = makeFakeRedis();
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            logger: mockLogger,
+            useDataStream: true,
+            // Replicator mode: no WebSocket connection in unit tests.
+            dataStream: { replicatorMode: true, redisClient },
+            creditLeases: {},
+        });
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining("creditLeases is configured but DataStream is not enabled"),
+        );
+        await client.close();
+    });
+
+    it("warns at construction when creditLeases is configured in offline mode", async () => {
+        const client = new SchematicClient({
+            offline: true,
+            logger: mockLogger,
+            creditLeases: {},
+        });
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("creditLeases is configured but the client is in offline mode"),
+        );
+        // Offline skips lease plumbing entirely — nothing to stop.
+        expect((client as any).leaseStore).toBeUndefined();
+        await client.close();
+    });
+
+    it("close() does not release outstanding leases (they reclaim via expiry, not shutdown)", async () => {
+        const { makeFakeRedis } = await import("./credits/fake-redis");
+        const redisClient = makeFakeRedis();
+        const client = new SchematicClient({
+            apiKey: "test-key",
+            logger: mockLogger,
+            creditLeases: {},
+            dataStream: { redisClient },
+        });
+        // A shared lease lives in the backend (could have been installed by this
+        // pod or a sibling). Releasing it on this pod's shutdown would pull the
+        // grant out from under siblings — so close() must leave it alone.
+        const leaseStore = (client as any).leaseStore;
+        await leaseStore.replace({
+            leaseId: "lse_shared",
+            companyId: "co_1",
+            creditTypeId: "ct_1",
+            grantedAmount: 1000,
+            expiresAt: new Date(Date.now() + 5 * 60_000),
+        });
+
+        await client.close();
+
+        // The old close() released + dropped every lease in the shared backend;
+        // the lease must now survive shutdown so siblings keep drawing on it.
+        const survivor = await leaseStore.get("co_1", "ct_1");
+        expect(survivor).toBeDefined();
+        expect(survivor?.leaseId).toBe("lse_shared");
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,40 @@
   resolved "https://registry.yarnpkg.com/@poppinss/exception/-/exception-1.2.3.tgz#b713855e6c9fe2110fea0949455c50828145e64a"
   integrity sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.6.1.tgz#c4636b7cb34e96008a988409b7e787364ae761a2"
+  integrity sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
+  integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
+
+"@redis/json@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.7.tgz#016257fcd933c4cbcb9c49cde8a0961375c6893b"
+  integrity sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==
+
+"@redis/search@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.2.0.tgz#50976fd3f31168f585666f7922dde111c74567b8"
+  integrity sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==
+
+"@redis/time-series@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.1.0.tgz#cba454c05ec201bd5547aaf55286d44682ac8eb5"
+  integrity sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
@@ -1632,6 +1666,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2060,6 +2099,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -3171,6 +3215,18 @@ readable-stream@^4.7.0:
     process "^0.11.10"
     string_decoder "^1.3.0"
 
+redis@^4.7.0:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.7.1.tgz#08588a30936be0e7ad9c0f3e1ac6a85ccaf73e94"
+  integrity sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.6.1"
+    "@redis/graph" "1.1.1"
+    "@redis/json" "1.0.7"
+    "@redis/search" "1.2.0"
+    "@redis/time-series" "1.1.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -3804,6 +3860,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Adds client-side credit burndown enforcement: `check()` preflight-reserves credits against locally-held leases (tranches acquired transactionally from the API), `trackWithReservation()` settles actual usage and refunds the delta to the lease, `prewarm()` / `identify({ prewarm })` warm leases ahead of a session's first check, and `getCreditBalance()` exposes a lease-aware balance for display. Opt-in via a `creditLeases` config block; existing `checkFlag` / `identify` / `track` are unchanged.

Lease-bearing checks require DataStream so the SDK has the cached flag + company to find the credit condition and substitute the lease balance for WASM eval; without it, `check` falls through to a plain `checkFlag`. The new preflight options (`usage` / `event_usage`) thread through every client-side eval path (datastream, replicator, plain `checkFlag`), not just leasing.

Lease + reservation state lives in the cache backend: with Redis configured (an existing `dataStream.redisClient` is reused automatically; `creditLeases.redisClient` only to point elsewhere), balances and the reservation table are shared cross-pod with atomic mutations via single-key Lua scripts (check-and-decrement on `tryReserve`, claim-and-refund on `consume`) and client-side lease/reservation expiry. Without Redis, single-pod in-memory stores. No new runtime dependency.