### PR TITLE
inline rules-engine WASM binary at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,16 +85,25 @@ jobs:
             echo "ERROR: dist/index.js not found"
             exit 1
           fi
-          if [ ! -f dist/wasm/rulesengine_bg.wasm ]; then
-            echo "ERROR: dist/wasm/rulesengine_bg.wasm not found"
-            echo "The build may have failed to copy WASM artifacts"
-            exit 1
-          fi
           if [ ! -f dist/wasm/rulesengine.js ]; then
             echo "ERROR: dist/wasm/rulesengine.js not found"
             exit 1
           fi
-          echo "Verified: WASM artifacts present in dist/wasm/"
+          # The .wasm binary is base64-inlined into rulesengine.js at build
+          # time (see build.js inlineWasmBinary), so the standalone .wasm
+          # is intentionally absent from dist/. Verify the inlining sentinel
+          # is present instead — guards against a future build change that
+          # silently reverts to the disk-loaded path.
+          if ! grep -q "WASM binary inlined at build time" dist/wasm/rulesengine.js; then
+            echo "ERROR: dist/wasm/rulesengine.js does not contain the inlined WASM sentinel"
+            echo "The build may have failed to run inlineWasmBinary()"
+            exit 1
+          fi
+          if [ -f dist/wasm/rulesengine_bg.wasm ]; then
+            echo "ERROR: dist/wasm/rulesengine_bg.wasm should have been removed by inlineWasmBinary()"
+            exit 1
+          fi
+          echo "Verified: WASM inlined into dist/wasm/rulesengine.js"
 
   publish:
     needs: [ compile, test, verify-package ]

--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 // build.js
 const esbuild = require('esbuild');
 const { execSync } = require('child_process');
-const { cpSync, mkdirSync, existsSync } = require('fs');
+const { cpSync, mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } = require('fs');
 
 const sharedConfig = {
   entryPoints: ['src/index.ts'],
@@ -52,6 +52,8 @@ async function build() {
     }
     console.log('✅ WASM artifacts copied to dist/wasm/');
 
+    inlineWasmBinary();
+
     // Generate TypeScript declarations with tsc
     console.log('🔧 Generating TypeScript declarations...');
     execSync('tsc --emitDeclarationOnly --outDir dist', { stdio: 'inherit' });
@@ -63,6 +65,57 @@ async function build() {
     console.error('❌ Build failed:', error);
     process.exit(1);
   }
+}
+
+// Inline the WASM binary into dist/wasm/rulesengine.js so the runtime no
+// longer reads it off disk via `fs.readFileSync(${__dirname}/...)`.
+//
+// The wasm-bindgen-generated loader resolves the .wasm file relative to
+// its own `__dirname`, which breaks the moment a downstream bundler
+// (webpack, Next.js, Vite, etc.) follows the require chain and rewrites
+// `__dirname` to point inside the bundle output — there's no `.wasm`
+// sibling there, so initialization fails with a misleading ENOENT.
+// See the linked Next.js failure mode at
+//   .next/dev/server/vendor-chunks/rulesengine_bg.wasm  →  ENOENT.
+//
+// Inlining the bytes as a base64 string sidesteps the whole class of
+// `__dirname`-aware loaders. Costs ~+138 KB on the tarball (550 KB
+// base64 string in JS replaces a 414 KB .wasm + the loader stub) but
+// makes the SDK bundler-agnostic for free. We delete the standalone
+// `.wasm` after rewriting since nothing reads it at runtime anymore.
+function inlineWasmBinary() {
+  const loaderPath = 'dist/wasm/rulesengine.js';
+  const binaryPath = 'dist/wasm/rulesengine_bg.wasm';
+  if (!existsSync(loaderPath) || !existsSync(binaryPath)) {
+    console.warn('⚠️  Skipping WASM inlining — files not found:', { loaderPath, binaryPath });
+    return;
+  }
+
+  const wasmBase64 = readFileSync(binaryPath).toString('base64');
+  const loaderSource = readFileSync(loaderPath, 'utf8');
+
+  // Match the wasm-bindgen-emitted block that reads the binary off disk.
+  // Captures any whitespace/comments wasm-bindgen emits between the two
+  // statements so future loader updates don't silently bypass this step.
+  const loaderPattern = /const wasmPath = `\$\{__dirname\}\/rulesengine_bg\.wasm`;\s*\nconst wasmBytes = require\('fs'\)\.readFileSync\(wasmPath\);/;
+  if (!loaderPattern.test(loaderSource)) {
+    throw new Error(
+      'WASM inlining failed: expected `const wasmPath = `${__dirname}/...`; const wasmBytes = require(\'fs\').readFileSync(wasmPath);` in ' +
+        loaderPath +
+        '. wasm-bindgen output shape changed — update inlineWasmBinary() to match.'
+    );
+  }
+
+  const inlined = loaderSource.replace(
+    loaderPattern,
+    `// WASM binary inlined at build time (see build.js inlineWasmBinary).\nconst wasmBytes = Buffer.from('${wasmBase64}', 'base64');`
+  );
+  writeFileSync(loaderPath, inlined);
+
+  // Standalone .wasm is dead weight once the bytes are embedded. Drop
+  // it so we don't ship two copies of the binary.
+  rmSync(binaryPath);
+  console.log(`✅ WASM inlined into ${loaderPath} (${wasmBase64.length} base64 chars, .wasm removed)`);
 }
 
 build();

--- a/src/rules-engine.ts
+++ b/src/rules-engine.ts
@@ -50,12 +50,15 @@ export class RulesEngineClient {
         }
 
         try {
-            // Dynamic require so the WASM module (which uses fs/path) is never
-            // pulled into edge/webpack bundles — it only loads in Node.js at runtime.
-            // The variable indirection prevents webpack from resolving the path statically.
-            const wasmPath = './wasm/rulesengine.js';
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const wasm = require(wasmPath);
+            // Load the WASM loader via dynamic import() so bundlers code-split it
+            // into its own async chunk rather than inlining the (base64) binary
+            // into a consumer's entry bundle. A consumer that only uses the HTTP
+            // API and never reaches initialize() therefore doesn't ship the wasm.
+            // The loader is a CommonJS module (wasm-bindgen nodejs target), so
+            // unwrap the interop `default` before reading the export.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ns: any = await import('./wasm/rulesengine.js');
+            const wasm = ns.RulesEngineJS ? ns : (ns.default ?? ns);
             this.wasmInstance = new wasm.RulesEngineJS();
             this.initialized = true;
         } catch (error) {


### PR DESCRIPTION
The wasm-bindgen `dist/wasm/rulesengine.js` loads its `.wasm` sibling via `fs.readFileSync(${__dirname}/...)`, which breaks under bundlers that rewrite `__dirname` (Next.js surfaces it as `ENOENT` at SDK init, and the rules engine silently falls back to API-only) and in runtimes without `fs`.

Two changes:

1. **Inline the WASM at build time** (`build.js`) — base64-encode the binary into the loader (`Buffer.from(...)`), removing the filesystem read, and drop the standalone `.wasm`. Init becomes bundler/runtime-agnostic. Tarball +138 KB.

2. **Load the loader via dynamic `import()`** (`src/rules-engine.ts`) instead of `require`, so bundlers code-split the wasm into its own async chunk. A consumer that only uses the HTTP API (never calls `initialize()`) no longer ships the inlined binary in its entry bundle — measured HTTP-only entry bundle: webpack/Next 282 KB → 71 KB gz, Vite/Rollup/esbuild-splitting 283 KB → 77 KB gz. (esbuild single-file mode still re-inlines.)

`verify-package` CI updated to assert the inlined sentinel and the absence of the standalone `.wasm`.

Follow-up SCH-6542: publish web/bundler wasm-bindgen targets for the size-optimal native WASM path on Cloudflare/edge.