### PR TITLE
testapp: honor eventCaptureBaseUrl from e2e configure payload

### DIFF
--- a/testapp/index.js
+++ b/testapp/index.js
@@ -103,6 +103,11 @@ async function handleConfigure(req, res) {
   if (config.baseUrl) {
     opts.basePath = config.baseUrl;
   }
+  if (config.eventCaptureBaseUrl) {
+    // Without this, events go to the SDK's default (production) capture
+    // endpoint and never reach the environment under test.
+    opts.eventCaptureBaseURL = config.eventCaptureBaseUrl;
+  }
   if (config.flagDefaults) {
     opts.flagDefaults = config.flagDefaults;
   }


### PR DESCRIPTION
The sdk-e2e harness passes `eventCaptureBaseUrl` in the `/configure` payload, but the testapp never mapped it into SDK options, so the SDK fell back to its default capture endpoint (production `c.schematichq.com`). All events from e2e runs against dev silently vanished into prod, which made every event-dependent test (`TestIdentify`, `TestTrackEvent`, and the new metric-propagation case in SchematicHQ/actions#472) fail or time out.

Verified locally: with this fix, the full sdk-e2e suite passes in datastream mode against `api.schematichq.dev`.