### PR TITLE
FIX: broken SDK 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@schematichq/schematic-typescript-node",
-    "version": "1.4.7",
+    "version": "1.5.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@schematichq/schematic-typescript-node",
-    "version": "1.5.0",
+    "version": "1.4.8",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/core/fetcher/custom.ts
+++ b/src/core/fetcher/custom.ts
@@ -28,7 +28,14 @@ export function provideFetcher(defaultHeaders?: Record<string, string>): FetchFu
             }
         }
 
-        const url = createRequestUrl(args.url, args.queryParameters);
+        // Newer Fern-generated clients pass a pre-built `queryString` (via
+        // core.url.queryBuilder()) instead of `queryParameters`. Honor it first,
+        // falling back to the legacy `queryParameters` path. Without this, any
+        // query params built into `queryString` are silently dropped.
+        const url =
+            args.queryString != null && args.queryString.length > 0
+                ? `${args.url}?${args.queryString}`
+                : createRequestUrl(args.url, args.queryParameters);
         let requestBody: BodyInit | undefined = await getRequestBody({
             body: args.body,
             type: args.requestType === "json" ? "json" : "other",


### PR DESCRIPTION
adjust our custom fetcher.js. fern deprecated using queryParams in favor of queryString in a recent update