### PR TITLE
Add language-agnostic conformance suite for credit lease semantics

### DIFF
--- a/conformance/SPEC.md
+++ b/conformance/SPEC.md
@@ -1,0 +1,440 @@
+# Credit lease & reservation semantics — conformance spec
+
+This document specifies the client-side credit lease/reservation semantics implemented by the
+Schematic Node SDK (the reference implementation), in enough detail to reimplement them in another
+language without reading the Node source. The machine-readable test vectors in
+`conformance/vectors/*.json` pin the observable behavior; this spec explains the model, the
+configuration knobs, and the invariants that cannot be expressed as deterministic vectors.
+
+Where this document and the vectors disagree, the vectors win — they are generated from the
+reference implementation's behavior.
+
+- [Vector format](#vector-format)
+- [Model overview](#model-overview)
+- [State](#state)
+- [Store operations](#store-operations)
+- [Lease manager](#lease-manager)
+- [Check flow](#check-flow)
+- [Track / settle flow](#track--settle-flow)
+- [Configuration knobs](#configuration-knobs)
+- [Bounded-leak contract](#bounded-leak-contract)
+- [Invariants not expressible as vectors](#invariants-not-expressible-as-vectors)
+
+## Vector format
+
+Each file in `conformance/vectors/` is a JSON document:
+
+```json
+{
+    "category": "reservation_lifecycle",
+    "vectors": [
+        {
+            "name": "unique_snake_case_name",
+            "description": "What this vector pins and why.",
+            "backends": ["in_memory", "redis"],
+            "given": {
+                "config": { "lease_duration_ms": 300000, "reservation_ttl_ms": 60000, "lease_size": 1000, "low_water_mark": 0.25 },
+                "leases": [ { "lease_id": "lse_1", "company_id": "co_1", "credit_type_id": "ct_1", "granted_amount": 1000, "expires_at_ms": 60000 } ]
+            },
+            "operations": [
+                { "op": "try_reserve", "company_id": "co_1", "credit_type_id": "ct_1", "credits": 100, "expect": { "balance": 900 } }
+            ]
+        }
+    ]
+}
+```
+
+Rules:
+
+- All keys are `snake_case`. Vectors are plain JSON — no language-specific types.
+- **Virtual clock.** The run starts at a fixed virtual instant `t0`. Every `*_at_ms` field is an
+  offset in milliseconds from `t0` (an absolute position on the virtual timeline, not relative to
+  the current operation). The `advance_clock` operation moves the clock forward; nothing else does.
+  Runners must execute vectors against a controllable clock (no wall time).
+- `backends` restricts which store backends the vector runs against; when omitted, the vector must
+  pass against every backend the SDK ships (in-memory and Redis for Node).
+- `given.leases` are installed via the store's `replace` operation at `t0` (each install must
+  return "written").
+- Assertions are attached per-operation via `expect`. Final-state assertions are expressed as
+  trailing read operations (`get_lease`, `reserved_credits`, `reservation_count`).
+- `expect.balance` / `expect.consumed` use JSON `null` for the "no / refused" result.
+- Reservation ids created by `check` operations are random; the vector names them via
+  `save_reservation_as` and later operations reference them with `handle`.
+
+### Operations
+
+Store-level (exercise the lease store and reservation store directly):
+
+| op | fields | expect |
+| --- | --- | --- |
+| `advance_clock` | `ms` | — |
+| `replace_lease` | `lease_id`, `company_id`, `credit_type_id`, `granted_amount`, `expires_at_ms` | `written` (bool) |
+| `drop_lease` | `company_id`, `credit_type_id` | — |
+| `try_reserve` | `company_id`, `credit_type_id`, `credits` | `balance` (post-debit number, or `null`) |
+| `refund_lease` | `company_id`, `credit_type_id`, `credits`, `pin_lease_id`? | — |
+| `extend_lease` | `company_id`, `credit_type_id`, `granted_total`, `expires_at_ms`?, `pin_lease_id`? | — |
+| `get_lease` | `company_id`, `credit_type_id` | `exists`, `lease_id`?, `granted_amount`?, `local_remaining_credits`? |
+| `add_reservation` | `id`, `lease_id`, `company_id`, `credit_type_id`, `event_subtype`, `quantity_reserved`, `credits_reserved`, `consumption_rate`, `expires_at_ms` | — |
+| `consume_reservation` | `id` or `handle`, `credits`, `crash_before_refund`? (bool, one-shot) | `consumed` (number or `null`), `throws`? |
+| `get_reservation` | `id` or `handle` | `exists` |
+| `reserved_credits` | `company_id`, `credit_type_id` | `total` |
+| `reservation_count` | — | `count` |
+| `sweep_expired` | — | `swept` |
+
+Manager-level (exercise the lease manager with a scripted wire client):
+
+| op | fields | expect |
+| --- | --- | --- |
+| `acquire_if_needed` | `company_id`, `credit_type_id`, `server`? ( `{ "lease": {...} }` or `{ "error": "..." }` ), `install_during_wire`? (lease installed into the store while the wire call is in flight, emulating a sibling pod winning the race) | `lease_id` (or `null`), `wire_acquires` (cumulative count), `last_acquire_requested_amount`?, `released_lease_ids` (cumulative) |
+| `maybe_extend` | `company_id`, `credit_type_id`, `required_credits`?, `server`? ( `{ "lease": { "granted_total", "expires_at_ms" } }` or `{ "error": "..." }` ) | `wire_extends` (cumulative count), `last_extend_additional_amount`?, `last_extend_lease_id`? |
+| `release_all_local_leases` | — (in-memory backend only) | `released_lease_ids`, `remaining_slots` |
+
+Flow-level (exercise the full check/track orchestration with a scripted rules engine):
+
+| op | fields | expect |
+| --- | --- | --- |
+| `check` | `flag_key`, `company` (`{ id, credit_balances }`), `usage`, `event_subtype`?, `on_acquire_failure`?, `engine` (array of scripted engine results, consumed in call order), `server`? (as above), `save_reservation_as`? | `allowed`, `reason`?, `err`?, `has_reservation`, `reservation`? (field subset), `fallback_called`?, `engine_calls`? (per-call `{ credit_balance, credit_cost?, event_usage? }`; `credit_balance` may be the string `"max_safe_integer"`) |
+| `track` | `handle`, `actual_quantity` | `settled_locally`, `track` (`{ event, quantity, lease_id }`) |
+
+A scripted engine result is `{ "value": bool, "reason"?: string, "entitlement"?: { "value_type",
+"credit_id"?, "consumption_rate"?, "event_subtype"?, "feature_id"?, "feature_key"? } }`. The engine
+is an oracle: the vectors pin the *orchestration around* the rules engine (what it is called with,
+and what the SDK does with its answer), not the engine itself — the engine is shared WASM across
+SDKs and has its own tests.
+
+## Model overview
+
+Credit-metered features are gated client-side without a wire call per check. The SDK:
+
+1. **Leases** a tranche of credits from the server per `(company_id, credit_type_id)`. The server
+   pre-debits the company balance by the granted amount; the SDK tracks a local view of how much
+   of the tranche remains un-reserved (`local_remaining_credits`).
+2. **Reserves** `usage x consumption_rate` credits from the lease at `check()` time, atomically
+   (check-and-debit). A successful, engine-approved check returns a *reservation handle*.
+3. **Settles** the reservation at `track()` time with the actual usage: the actually-consumed
+   credits stay debited, the unspent slice is refunded to the lease, and a Track event bills the
+   server (the server is the source of truth for real consumption).
+
+Everything client-side is *local bookkeeping against the leased tranche*. The server reconciles:
+an expired lease's unspent remainder is refunded to the company balance server-side, and Track
+events (keyed by `lease_id`) drive the authoritative consumption.
+
+Leases and reservations both expire:
+
+- A **lease** past its expiry must be treated as *released* — its local balance is stale (the
+  server already refunded the remainder) and must never serve another reserve or be extended.
+- A **reservation** past its TTL is swept: removed from the table and its full hold refunded to
+  the lease. Work that finishes after the sweep still bills the server (recovery emit) but does
+  not re-debit the local lease.
+
+## State
+
+**Lease slot** — at most one lease per `(company_id, credit_type_id)` key:
+
+| field | meaning |
+| --- | --- |
+| `lease_id` | Server-issued id. |
+| `granted_amount` | Server-authoritative total granted to this lease (grows on extend). |
+| `local_remaining_credits` | Local view: granted minus outstanding holds/consumption. Initialized to `granted_amount` on install. |
+| `expires_at` | Expiry instant. Past it the lease is dead (see above). |
+
+**Reservation** — keyed by a unique id:
+
+| field | meaning |
+| --- | --- |
+| `id` | Unique (UUID in Node). |
+| `lease_id` | The lease the hold was carved from. Pins refunds. |
+| `company_id`, `credit_type_id` | Slot key. |
+| `event_subtype` | Event the settle will bill as. |
+| `quantity_reserved` | Caller-declared usage (event units). |
+| `credits_reserved` | `quantity_reserved x consumption_rate`. |
+| `consumption_rate` | Rate at reservation time. |
+| `expires_at` | Reservation TTL deadline (sweep target). |
+| `eval_ctx` | Company/user keys used at check time; threaded onto the Track event. |
+
+## Store operations
+
+These are the primitives both store backends (per-process in-memory; shared Redis) must implement
+with identical observable semantics. Each mutation must be atomic per slot/reservation (see
+[Invariants](#invariants-not-expressible-as-vectors)).
+
+### `replace(lease)` — install-if-not-live
+
+Install a fresh lease with `local_remaining_credits = granted_amount`, **only if** the slot is
+empty or the existing lease is expired. If a *live* lease occupies the slot — even with a
+different `lease_id` (a sibling pod won the race) — leave it untouched (its already-debited
+balance wins) and report "kept". Returns written/kept so the caller can run the redundant-lease
+release logic (see manager).
+
+### `try_reserve(company, credit, credits)` — atomic check-and-debit
+
+- Reject (return `null`, touch nothing) if: no lease in the slot; the lease is **expired**; the
+  remaining balance is `< credits`; or `credits` is not a finite non-negative number (NaN must
+  never reach the arithmetic — it slips through every comparison and would poison the balance
+  into approving everything).
+- Otherwise debit and return the **post-debit balance** (so the caller can derive the pre-debit
+  figure as `returned + credits` without a racy follow-up read).
+- Reserving down to exactly 0 is allowed.
+
+### `refund(company, credit, credits, pin_lease_id?)`
+
+Add credits back to `local_remaining_credits`, **clamped at `granted_amount`**. No-op if
+`credits <= 0` or no lease is in the slot. When `pin_lease_id` is given, the refund applies
+**only if** the slot still holds that lease: a hold carved out of expired lease A must never
+inflate successor lease B — A's remainder (including this slice) was already refunded to the
+company balance server-side when A expired, so crediting B would double-count.
+
+### `extend(company, credit, granted_total, new_expires_at?, pin_lease_id?)` — reconcile to total
+
+After a remote extend, reconcile the slot to the **server-authoritative total**:
+
+- Compute `delta = granted_total - stored granted_amount` **atomically against the currently
+  stored total** — never from a caller-held pre-wire-call read (two pods extending concurrently
+  from the same stale read would each apply a delta and mint phantom credits). If `delta > 0`,
+  set `granted_amount = granted_total` and add `delta` to `local_remaining_credits`. If
+  `delta <= 0` (a total a sibling already applied, or a stale lower total) it is a **no-op** —
+  applies converge in any order.
+- Expiry only ever moves **forward**: `new_expires_at` is applied only if later than the stored
+  expiry, so an out-of-order apply cannot shorten a lease a sibling just extended.
+- When `pin_lease_id` is given and the slot holds a different lease, drop the whole extend
+  (credits and expiry): the server granted the extension to the pinned lease; crediting a
+  successor would mint credits the server refunds with the pinned lease at its expiry.
+- No-op if the slot is empty.
+
+### `drop(company, credit)`
+
+Remove the slot entry (after a remote release). Plain delete.
+
+### Reservation table: `add`, `get`, `consume`, `reserved_credits`, `sweep_expired`
+
+- `add(reservation)` — register. Idempotent on id. `add` does NOT debit the lease; the debit
+  already happened in `try_reserve` (see [ordering](#bounded-leak-contract)).
+- `consume(id, credits_consumed)` — **exactly-once claim**: atomically remove the reservation
+  from the table; if it was already gone (swept, or consumed by a racing caller) return `null`
+  and touch nothing. On a successful claim, clamp `credits_consumed` to
+  `[0, credits_reserved]`, refund `credits_reserved - clamped` to the lease (pinned to the
+  reservation's `lease_id`), and return the clamped figure. The claim and the refund are two
+  steps; the claim is the arbiter (see bounded-leak contract).
+- `reserved_credits(company, credit)` — sum of `credits_reserved` across open reservations for
+  the slot. A reservation counts iff it is still in the table, so
+  `local_remaining_credits + reserved_credits` stays exact between operations.
+- `sweep_expired(now)` — remove every reservation with `expires_at <= now` and refund its full
+  hold to its lease (pinned to its `lease_id`; a stale-lease hold is dropped, not refunded).
+  Returns the number swept. Runs on a background interval (`sweep_interval_ms`) in production;
+  vectors call it explicitly.
+
+## Lease manager
+
+Owns the lease lifecycle against the server wire API (`acquire`, `extend`, `release`).
+
+### Acquire (`acquire_if_needed`)
+
+- If the slot holds a **live** lease, return it — no wire call.
+- Otherwise call the server: `requested_amount = lease_size`, `expires_at = now +
+  lease_duration_ms`. An expired local entry is left in place for `replace` to overwrite
+  atomically (deleting it first would open a race window against sibling pods; every reader
+  re-guards on expiry anyway).
+- On response, `replace` the slot. If `replace` kept an existing live lease (a sibling won):
+  - If the installed lease has a **different id** than the one the server handed us, ours is a
+    redundant hold nobody will draw on — release it (fire-and-forget; a failed release falls
+    back to server-side lease expiry).
+  - If the ids are the **same** (the server is idempotent for an active slot and handed the
+    racing acquire the sibling's lease back), release **nothing** — releasing would pull the
+    shared lease out from under every sibling.
+  - If the slot reads empty (expired in the gap), also release nothing.
+  - Either way, return whatever the slot now holds.
+- Wire or store failure: return "no lease" (never throw) — the caller routes it through
+  fail-open/fail-closed.
+- Per-process single-flight per slot: concurrent callers share one in-flight wire call
+  (best-effort; duplicates are absorbed by the idempotent server + `replace`).
+
+### Extend (`maybe_extend`)
+
+Triggered when EITHER:
+
+- `local_remaining_credits / max(granted_amount, 1) <= low_water_mark` (steady-state refresh), or
+- the caller passes `required_credits` and `local_remaining_credits < required_credits` (a check
+  just failed a reserve of that size — extend opportunistically).
+
+Rules:
+
+- **Never extend an expired lease** — the server treats it as released; the right move is a fresh
+  acquire on the next check.
+- Wire body: `additional_amount = max(lease_size, required_credits - local_remaining_credits)`.
+  Sizing to the shortfall matters: a single check needing more than `remaining + lease_size`
+  would otherwise fail its post-extend retry forever regardless of server balance.
+  `expires_at = now + lease_duration_ms`.
+- On response, reconcile via the store's `extend` with the server's **total** and new expiry,
+  **pinned** to the extended lease's id.
+- Failures resolve to "no lease" without throwing (often fire-and-forget).
+- Per-process single-flight per slot, kept separate from acquire's (an in-flight extend must not
+  satisfy an acquire, or vice versa).
+
+### Release on close (`release_all_local_leases`)
+
+Only for a **per-process (in-memory) store**, whose leases are exclusively this process's:
+release every live lease over the wire (returning the unspent remainder to the company balance
+immediately) and drop it locally; **skip expired** leases (already swept server-side). A shared
+(Redis) store must never do this — sibling pods still draw on those leases. Best-effort:
+failures fall back to server-side expiry.
+
+## Check flow
+
+`check(eval_ctx, flag_key, { usage, event_subtype?, on_acquire_failure?, ... })` — the
+lease-gated feature check. Fallback = the plain (non-lease) flag check, which has its own
+degradation story; when the flow "falls back", no reservation is issued and no lease state is
+touched beyond what already happened.
+
+Guards, in order:
+
+1. `usage` missing → plain check (lease path not requested).
+2. `usage` not a finite non-negative number → resolve **statically** by `on_acquire_failure`
+   (deny for fail-closed; blanket allow for fail-open, reason `invalid_usage`). The value must
+   never reach the stores.
+3. `usage == 0` → nothing to reserve; fall back to the plain check (no 0-credit reservation).
+4. No datastream / cached flag / resolvable company (or named user) → fall back.
+
+Then:
+
+5. **Entitlement probe.** Run the rules engine once against the company's *real* balance — no
+   substitution, no credit-cost preflight (a preflight against the lease-depleted server balance
+   could fail the credit condition and hide the entitlement being probed for). Read the matched
+   entitlement's shape:
+   - Not credit-metered (`value_type != "credit"`: boolean/override grant, numeric allocation,
+     unlimited, or not entitled) → **fall back**, no lease traffic at all.
+   - Credit entitlement missing `credit_id`, a positive `consumption_rate`, or a resolvable
+     `event_subtype` (caller's explicit subtype wins over the entitlement's) → fall back.
+   - Probe error → fall back (it is a resolution step, not the gate).
+6. `credit_cost = usage x consumption_rate`.
+7. **Acquire** a lease for `(company, credit_id)`. Failure → [failure handling](#failure-handling)
+   with reason `lease_acquire_failed`.
+8. **Reserve** `credit_cost` via `try_reserve`. On refusal, opportunistically
+   `maybe_extend(required_credits = credit_cost)` (awaited) and retry the reserve **once**.
+   Still refused → failure handling, reason `insufficient_lease_balance`. Store error →
+   failure handling, reason `lease_store_error`.
+9. **Record the reservation** (TTL = `reservation_ttl_ms` from now) — *after* the debit, *before*
+   the engine gate. If persisting fails, undo the debit (claim-and-refund; direct refund if
+   nothing persisted; both pinned to the lease) and go to failure handling
+   (`lease_store_error`). If even the undo fails, accept the bounded leak.
+10. **Engine gate.** Re-run the engine against a company snapshot whose
+    `credit_balances[credit_id]` is substituted with the **pre-reservation** local balance
+    (post-debit balance returned by `try_reserve` + `credit_cost` — exact as of the debit, no
+    read race), passing `credit_cost = { credit_id: credit_cost }` so the engine evaluates
+    `pre_reservation - credit_cost >= 0` — the same arithmetic `try_reserve` just enforced, plus
+    every non-credit rule (plan targeting, overrides).
+    - Engine **allows** → keep the hold; return `{ allowed: true, reservation }`. Fire-and-forget
+      a watermark-driven `maybe_extend`.
+    - Engine **denies** → cancel the reservation (claim + full refund) and return
+      `{ allowed: false }` with the engine's reason.
+    - Engine **errors** → cancel the reservation and resolve **statically** by mode (the engine
+      itself is down, so no fail-open re-evaluation is possible).
+
+### Failure handling
+
+Every can't-gate outcome (acquire failed, store unreachable, lease exhausted) funnels through the
+configured `on_acquire_failure` mode (default **fail-closed**):
+
+- **fail-closed** → `{ allowed: false }`, reason = the failure reason. No reservation.
+- **fail-open** → *err on the side of assuming the credits are there*, **not** blanket allow:
+  re-run the engine with the credit balance substituted to an effectively unlimited value
+  (`MAX_SAFE_INTEGER` in Node) and the caller's usage preflight threaded through. Plan
+  targeting, overrides, and every non-credit condition still apply — a company that is not
+  entitled stays **denied** even with the lease backend down. No reservation is issued either
+  way; `err` carries the failure reason. Only if that evaluation itself errors does the SDK
+  fall back to a blanket allow.
+
+## Track / settle flow
+
+`track_with_reservation(reservation, actual_quantity)` settles a reservation:
+
+1. `credits = actual_quantity x reservation.consumption_rate`.
+2. `consume(reservation.id, credits)`:
+   - **Settled locally** (claim succeeded): the clamped consumed slice stays debited; the unspent
+     slice is refunded to the lease (pinned).
+   - **Not settled** (`null`: already swept after TTL, already consumed, or store unreachable):
+     local lease state is untouched — if the sweeper already refunded the full hold, nothing
+     re-debits the consumed slice, so the local balance reads **high** until the lease rolls
+     over. This is why `reservation_ttl_ms` should exceed the longest expected gap between
+     `check()` and `track_with_reservation()`.
+3. Either way, emit the Track event built from the **caller-held handle** (not the store):
+   `event = event_subtype`, `quantity = actual_quantity` (the *unclamped* actual — the server is
+   the source of truth for real consumption; only local bookkeeping clamps to the reserved
+   amount), `lease_id = reservation.lease_id` (routes the server-side consumption through the
+   lease's sub-ledger instead of double-debiting the pre-debited grant), plus the reservation's
+   `eval_ctx` company/user and any caller traits.
+4. The Track carries a deterministic idempotency key derived from the reservation id
+   (`"lease-reservation:" + reservation.id` in Node); the server dedupes by it for 24h, so a
+   recovery emit racing the normal emit, or an accidental double settle, collapses to one billed
+   event across pods and restarts.
+5. Guard: a non-finite or negative `actual_quantity` skips the settle entirely (no store call, no
+   event) — the untouched reservation expires at its TTL and the sweeper refunds the full hold.
+
+## Configuration knobs
+
+| knob (vector key) | Node name | default | meaning |
+| --- | --- | --- | --- |
+| `lease_duration_ms` | `defaultLeaseDuration` | 300 000 (5 min) | Lease lifetime requested at acquire/extend (`expires_at = now + duration`). |
+| `reservation_ttl_ms` | `defaultReservationTTL` | 60 000 (60 s) | Reservation lifetime; the sweep deadline. Size above the longest expected check→track gap. |
+| `lease_size` | `defaultLeaseSize` | 10 000 | Credits requested per acquire, and the minimum extend tranche. |
+| `low_water_mark` | `lowWaterMark` | 0.25 | Remaining/granted ratio at or below which a background extend is kicked off. |
+| `sweep_interval_ms` | `sweepIntervalMs` | 1 000 | Expired-reservation sweep cadence. |
+| — | `onAcquireFailure` | `fail-closed` | Per-check failure mode (see check flow). |
+
+Per-credit-type overrides of the first four are supported (keyed by credit type id); resolution is
+override → client config → default.
+
+## Bounded-leak contract
+
+The flow deliberately orders its two-step transitions so that a process crash between steps leaks
+*locally held credits* (which the server reclaims at lease expiry) rather than enabling a
+double-spend. The invariant direction is always: **the debit/claim is durable first; the
+record/refund may be lost.**
+
+| # | crash window | what leaks | bound | reclaimed by | must NOT happen |
+| --- | --- | --- | --- | --- | --- |
+| 1 | after `try_reserve` (debit), before `add` (record) | the debited hold — invisible to the reservation table, so the sweeper can never refund it | `credits_reserved` of that one check | lease expiry: the expired balance is never served again, and the server refunds the whole grant; the successor lease installs at full grant | a reservation record without a debit (a later consume would refund credits never held → double-spend). Vectors pin that the debit lands strictly before the record. |
+| 2 | inside `consume`: after the claim, before the refund | the unspent slice of that reservation | `credits_reserved` of that one reservation | lease expiry (same mechanism) | a double refund: the claim is exactly-once, so a retried settle or a sweeper finds nothing to claim and refunds nothing |
+| 3 | (Redis only) after the claim, before index cleanup | nothing (bookkeeping only): the per-slot reserved-credits index transiently over-counts | one index field | the sweeper reconciles the orphaned index entry — **without refunding** (without the claimed record, exactly-once cannot be arbitrated across racing sweepers) | a refund driven by an index entry alone |
+
+Additional pinned properties:
+
+- A leak never survives its lease: after lease expiry the stale balance is refused
+  (`try_reserve → null`) and a successor lease restores the full grant.
+- A retried check after a window-1 crash settles independently: its own slice refunds exactly
+  once; the leaked slice never refunds.
+- A late retried settle after a window-2 crash (even after a successor lease is installed)
+  refunds nothing into the successor.
+
+## Invariants not expressible as vectors
+
+These hold in the reference implementation but need concurrency, wall clocks, or non-JSON values
+to demonstrate; ports must uphold them and should test them natively.
+
+1. **Per-slot atomicity.** `replace`, `try_reserve`, `refund`, `extend` are atomic per lease
+   slot; `consume`'s claim is atomic per reservation. In-memory: per-key mutual exclusion. Redis:
+   single-key Lua scripts (single-key keeps them Redis-Cluster-safe; the refund to the lease hash
+   is deliberately a separate single-key step, never a multi-key script — see leak window 2/3).
+2. **Server-clock expiry (shared backend).** With a shared store, lease expiry must be decided
+   against the *store's* clock (Redis `TIME`), not the calling process's — pods with skewed
+   clocks must agree on liveness. Backend rows carry a TTL grace window past `expires_at`
+   (60 s lease / 30 s reservation in Node) so the sweeper can still read them; expired-but-not-
+   evicted rows must still refuse reserves.
+3. **NaN/precision guards.** Non-finite or negative amounts are rejected at every boundary
+   (`usage`, `try_reserve`, `actual_quantity`) — JSON cannot encode NaN, so vectors only cover
+   the negative case. Fractional credit amounts are legal throughout (rates like 0.1); Redis
+   stores balances as strings to avoid integer truncation.
+4. **Single-flight.** Per-process, per-slot single-flight for acquire and for extend, tracked
+   separately. Best-effort only: duplicate wire calls are safe (idempotent server + keep-first
+   `replace` + reconcile-to-total `extend`).
+5. **Concurrent cross-pod extends converge.** Two pods extending from the same stale read must
+   not double-count — guaranteed by reconcile-to-total computed inside the store (the sequential
+   out-of-order-totals vector pins the arithmetic; the concurrent schedule needs a race).
+6. **Idempotent billing.** The Track idempotency key is deterministic from the reservation id;
+   the server dedupes for 24h. Double settles and recovery emits collapse to one billed event.
+7. **Background sweep loop.** `start_sweep`/`stop` run `sweep_expired` on an interval; timers
+   must not keep the process alive. Vectors call `sweep_expired` explicitly instead.
+8. **Fire-and-forget never rejects.** `acquire_if_needed`, `maybe_extend`, and release paths
+   resolve (to "no lease") on failure rather than rejecting — they are often unawaited.
+9. **Offline/unconfigured degradation.** Lease config absent → `check` is a plain flag check;
+   `track_with_reservation` on an unconfigured client still emits the billing event with the
+   `lease_id` and idempotency key intact.

--- a/conformance/vectors/check-flow.json
+++ b/conformance/vectors/check-flow.json
@@ -1,0 +1,527 @@
+{
+    "category": "check_flow",
+    "vectors": [
+        {
+            "name": "check_happy_path_gates_on_pre_reservation_balance",
+            "description": "A lease-bearing check: probe against the real balance (no substitution, no credit cost), reserve usage x rate from the lease, then gate the engine on the PRE-reservation local balance with credit_cost — the same arithmetic the atomic reserve just enforced. The hold sticks only because the engine allowed.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "save_reservation_as": "r1",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "ok" }
+                    ],
+                    "expect": {
+                        "allowed": true,
+                        "has_reservation": true,
+                        "reservation": {
+                            "lease_id": "lse_1",
+                            "credit_type_id": "ct_1",
+                            "event_subtype": "inference_tokens",
+                            "quantity_reserved": 10,
+                            "credits_reserved": 100,
+                            "consumption_rate": 10
+                        },
+                        "engine_calls": [{ "credit_balance": 5000 }, { "credit_balance": 1000, "credit_cost": 100 }]
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 100 } }
+            ]
+        },
+        {
+            "name": "check_denied_by_engine_cancels_the_hold",
+            "description": "When the gate evaluation denies, the reservation made before the eval is cancelled: claimed and fully refunded, leaving no hold and no reservation.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": false, "reason": "denied_by_targeting" }
+                    ],
+                    "expect": { "allowed": false, "reason": "denied_by_targeting", "has_reservation": false }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 0 } },
+                { "op": "reservation_count", "expect": { "count": 0 } }
+            ]
+        },
+        {
+            "name": "check_acquire_failure_fail_closed_denies",
+            "description": "fail-closed (the default): when no lease can be acquired the check denies outright with the failure reason; no reservation is issued.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-closed",
+                    "server": { "acquire": { "error": "wire down" } },
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        }
+                    ],
+                    "expect": {
+                        "allowed": false,
+                        "reason": "lease_acquire_failed",
+                        "err": "lease_acquire_failed",
+                        "has_reservation": false
+                    }
+                },
+                { "op": "reservation_count", "expect": { "count": 0 } }
+            ]
+        },
+        {
+            "name": "check_acquire_failure_fail_open_reevaluates",
+            "description": "fail-open is NOT blanket allow: the engine re-runs with the credit balance substituted to an effectively unlimited value and the caller's usage preflight threaded through, so non-credit rules still apply. Here they pass, so the check allows — with the failure recorded in err and no reservation.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-open",
+                    "server": { "acquire": { "error": "wire down" } },
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "evaluated" }
+                    ],
+                    "expect": {
+                        "allowed": true,
+                        "reason": "evaluated (lease_acquire_failed_fail_open)",
+                        "err": "lease_acquire_failed",
+                        "has_reservation": false,
+                        "engine_calls": [
+                            { "credit_balance": 5000 },
+                            {
+                                "credit_balance": "max_safe_integer",
+                                "event_usage": { "event_subtype": "inference_tokens", "quantity": 10 }
+                            }
+                        ]
+                    }
+                },
+                { "op": "reservation_count", "expect": { "count": 0 } }
+            ]
+        },
+        {
+            "name": "check_fail_open_still_denies_when_rules_deny",
+            "description": "fail-open with a denying rules evaluation stays denied: substituting an unlimited balance only bypasses the credit gate, never plan targeting or overrides.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-open",
+                    "server": { "acquire": { "error": "wire down" } },
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": false, "reason": "not_targeted" }
+                    ],
+                    "expect": {
+                        "allowed": false,
+                        "reason": "not_targeted (lease_acquire_failed_fail_open)",
+                        "err": "lease_acquire_failed",
+                        "has_reservation": false
+                    }
+                }
+            ]
+        },
+        {
+            "name": "check_insufficient_lease_extends_and_retries",
+            "description": "A reserve refusal triggers an awaited opportunistic extend sized to cover the request (required_credits = credit_cost), then exactly one reserve retry. On success the check proceeds normally, gating on the post-extend pre-reservation balance.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 950,
+                    "expect": { "balance": 50 }
+                },
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "server": { "extend": { "lease": { "granted_total": 2000, "expires_at_ms": 600000 } } },
+                    "save_reservation_as": "r1",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "ok" }
+                    ],
+                    "expect": {
+                        "allowed": true,
+                        "has_reservation": true,
+                        "wire_extends": 1,
+                        "last_extend_additional_amount": 1000,
+                        "engine_calls": [{ "credit_balance": 5000 }, { "credit_balance": 1050, "credit_cost": 100 }]
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 2000, "local_remaining_credits": 950 }
+                }
+            ]
+        },
+        {
+            "name": "check_insufficient_lease_after_failed_extend_resolves_by_mode",
+            "description": "When the opportunistic extend fails and the retry is still refused, the check resolves through the failure mode (fail-closed here) with reason insufficient_lease_balance, leaving the lease balance untouched.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 950,
+                    "expect": { "balance": 50 }
+                },
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-closed",
+                    "server": { "extend": { "error": "wire down" } },
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        }
+                    ],
+                    "expect": {
+                        "allowed": false,
+                        "reason": "insufficient_lease_balance",
+                        "err": "insufficient_lease_balance",
+                        "has_reservation": false
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 50 }
+                },
+                { "op": "reservation_count", "expect": { "count": 0 } }
+            ]
+        },
+        {
+            "name": "check_falls_back_without_usable_credit_entitlement",
+            "description": "A non-credit matched entitlement (boolean/override/numeric/unlimited/not entitled) or an incomplete credit entitlement (no positive consumption rate) defers to the plain check: no lease traffic, no reservation.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": {} },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "engine": [{ "value": true, "reason": "probe", "entitlement": { "value_type": "boolean" } }],
+                    "expect": { "fallback_called": true, "reason": "fallback", "has_reservation": false }
+                },
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 0,
+                                "event_subtype": "inference_tokens"
+                            }
+                        }
+                    ],
+                    "expect": { "fallback_called": true, "reason": "fallback", "has_reservation": false }
+                },
+                { "op": "reservation_count", "expect": { "count": 0 } }
+            ]
+        },
+        {
+            "name": "check_zero_usage_falls_back",
+            "description": "usage = 0 means nothing to reserve: the check defers to the plain (preflight-threaded) check instead of issuing a no-op 0-credit reservation.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 0,
+                    "event_subtype": "inference_tokens",
+                    "engine": [],
+                    "expect": { "fallback_called": true, "reason": "fallback", "has_reservation": false }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "check_invalid_usage_resolves_statically_by_mode",
+            "description": "A negative (or non-finite) usage must never reach the stores; the check resolves statically by mode without any engine evaluation: deny for fail-closed, blanket allow for fail-open, reason invalid_usage either way.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": -5,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-closed",
+                    "engine": [],
+                    "expect": {
+                        "allowed": false,
+                        "reason": "invalid_usage",
+                        "err": "invalid_usage",
+                        "has_reservation": false,
+                        "engine_calls": []
+                    }
+                },
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": -5,
+                    "event_subtype": "inference_tokens",
+                    "on_acquire_failure": "fail-open",
+                    "engine": [],
+                    "expect": {
+                        "allowed": true,
+                        "reason": "invalid_usage_fail_open",
+                        "err": "invalid_usage",
+                        "has_reservation": false,
+                        "engine_calls": []
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/crash-windows.json
+++ b/conformance/vectors/crash-windows.json
@@ -1,0 +1,271 @@
+{
+    "category": "crash_window",
+    "vectors": [
+        {
+            "name": "debit_without_record_leaks_bounded",
+            "description": "Crash window 1 (debit-then-add): the atomic debit landed but the reservation record never did. The leak is exactly the reserved amount; the sweeper can never refund a hold that was never recorded.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 0 } },
+                { "op": "advance_clock", "ms": 55000 },
+                { "op": "sweep_expired", "expect": { "swept": 0 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                }
+            ]
+        },
+        {
+            "name": "debit_leak_reclaimed_at_lease_expiry",
+            "description": "Crash window 1 recovery: the leaked balance is never served after lease expiry, and the successor lease installs at the full grant — the leak does not outlive the lease.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 1,
+                    "expect": { "balance": null }
+                },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 180000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "retried_check_after_debit_leak_settles_once",
+            "description": "A retry after a window-1 crash is a fresh check with a fresh reservation: its unspent slice refunds exactly once; the leaked slice never refunds — not on a repeat consume, not on a sweep.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 3600000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 800 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_retry",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_retry", "credits": 40, "expect": { "consumed": 40 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 860 }
+                },
+                { "op": "consume_reservation", "id": "res_retry", "credits": 40, "expect": { "consumed": null } },
+                { "op": "advance_clock", "ms": 70000 },
+                { "op": "sweep_expired", "expect": { "swept": 0 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 860 }
+                }
+            ]
+        },
+        {
+            "name": "crash_before_refund_claim_is_durable",
+            "description": "Crash window 2 (consume-then-refund): the claim survives the crash, so the reservation is gone everywhere and nothing can double-spend; the unspent slice's refund is lost, bounded by credits_reserved. A retried settle neither re-claims nor double-refunds, and the sweeper cannot refund a claimed reservation.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 3600000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "consume_reservation",
+                    "id": "res_1",
+                    "credits": 30,
+                    "crash_before_refund": true,
+                    "expect": { "throws": true }
+                },
+                { "op": "get_reservation", "id": "res_1", "expect": { "exists": false } },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 0 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 30, "expect": { "consumed": null } },
+                { "op": "advance_clock", "ms": 70000 },
+                { "op": "sweep_expired", "expect": { "swept": 0 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                }
+            ]
+        },
+        {
+            "name": "crash_before_refund_reclaimed_at_lease_expiry",
+            "description": "Crash window 2 recovery: after the lease expires and a successor takes the slot at full grant, a very late retried settle of the crashed reservation must not leak the lost refund into the successor.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "consume_reservation",
+                    "id": "res_1",
+                    "credits": 30,
+                    "crash_before_refund": true,
+                    "expect": { "throws": true }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 1,
+                    "expect": { "balance": null }
+                },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 180000,
+                    "expect": { "written": true }
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 0, "expect": { "consumed": null } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_2", "local_remaining_credits": 1000 }
+                }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/expiry.json
+++ b/conformance/vectors/expiry.json
@@ -1,0 +1,198 @@
+{
+    "category": "expiry",
+    "vectors": [
+        {
+            "name": "expired_lease_never_serves_reserves",
+            "description": "Past its expiry a lease's balance is stale (the server refunded the grant): reserves are refused even with ample local balance.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 1,
+                    "expect": { "balance": null }
+                }
+            ]
+        },
+        {
+            "name": "successor_after_expiry_restores_full_grant",
+            "description": "A successor lease installed over an expired slot starts at its full grant — nothing from the expired lease (debits or leaks) carries over.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 700,
+                    "expect": { "balance": 300 }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 180000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_2", "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "sweep_refunds_expired_holds_only",
+            "description": "The sweeper refunds an expired reservation's full hold to its lease and leaves live reservations untouched.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 300,
+                    "expect": { "balance": 700 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_short",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 10000
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_long",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 20,
+                    "credits_reserved": 200,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 200000
+                },
+                { "op": "sweep_expired", "expect": { "swept": 0 } },
+                { "op": "advance_clock", "ms": 10001 },
+                { "op": "sweep_expired", "expect": { "swept": 1 } },
+                { "op": "get_reservation", "id": "res_short", "expect": { "exists": false } },
+                { "op": "get_reservation", "id": "res_long", "expect": { "exists": true } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 800 }
+                },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 200 } }
+            ]
+        },
+        {
+            "name": "sweep_of_stale_lease_hold_does_not_inflate_successor",
+            "description": "Sweeping (or consuming) a reservation carved from an expired lease refunds nothing into the successor lease occupying the slot: the hold is pinned to its originating lease_id.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_stale",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 90000
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 300000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 200,
+                    "expect": { "balance": 800 }
+                },
+                { "op": "advance_clock", "ms": 30000 },
+                { "op": "sweep_expired", "expect": { "swept": 1 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_2", "local_remaining_credits": 800 }
+                }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/lease-lifecycle.json
+++ b/conformance/vectors/lease-lifecycle.json
@@ -1,0 +1,395 @@
+{
+    "category": "lease_lifecycle",
+    "vectors": [
+        {
+            "name": "replace_installs_full_grant",
+            "description": "A fresh install initializes local_remaining_credits to the full granted amount.",
+            "operations": [
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 60000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": {
+                        "exists": true,
+                        "lease_id": "lse_1",
+                        "granted_amount": 1000,
+                        "local_remaining_credits": 1000
+                    }
+                }
+            ]
+        },
+        {
+            "name": "replace_keeps_live_lease_even_with_different_id",
+            "description": "A live lease occupying the slot wins over any replace — even one carrying a different lease_id (a sibling raced this acquire). Its already-debited balance is preserved.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 400,
+                    "expect": { "balance": 600 }
+                },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 5000,
+                    "expires_at_ms": 120000,
+                    "expect": { "written": false }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": {
+                        "exists": true,
+                        "lease_id": "lse_1",
+                        "granted_amount": 1000,
+                        "local_remaining_credits": 600
+                    }
+                }
+            ]
+        },
+        {
+            "name": "replace_overwrites_expired_lease",
+            "description": "An expired lease does not block the slot: replace overwrites it atomically and restores the full new grant.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 400,
+                    "expect": { "balance": 600 }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_2",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 180000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_2", "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "try_reserve_insufficient_and_boundary",
+            "description": "A reserve larger than the remaining balance is refused and touches nothing; reserving down to exactly zero is allowed; negative amounts are always refused.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 100,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 101,
+                    "expect": { "balance": null }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 100 }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": -1,
+                    "expect": { "balance": null }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 0 }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 1,
+                    "expect": { "balance": null }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_9",
+                    "credit_type_id": "ct_1",
+                    "credits": 1,
+                    "expect": { "balance": null }
+                }
+            ]
+        },
+        {
+            "name": "refund_clamped_at_granted_amount",
+            "description": "A refund can never push the local balance above the granted amount.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                { "op": "refund_lease", "company_id": "co_1", "credit_type_id": "ct_1", "credits": 500 },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "refund_pinned_to_lease_id_dropped_on_successor",
+            "description": "A refund pinned to an expired lease's id must not inflate the successor lease occupying the slot — the expired lease's remainder was already returned to the company balance server-side. An unpinned refund still applies.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_2",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 200,
+                    "expect": { "balance": 800 }
+                },
+                {
+                    "op": "refund_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "pin_lease_id": "lse_1"
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 800 }
+                },
+                {
+                    "op": "refund_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "pin_lease_id": "lse_2"
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                }
+            ]
+        },
+        {
+            "name": "extend_reconciles_to_total_and_converges",
+            "description": "Extend applies the server-authoritative TOTAL: the delta is computed against the stored total, so a repeated or stale-lower total is a no-op and out-of-order applies converge without minting credits.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 800,
+                    "expect": { "balance": 200 }
+                },
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 3000,
+                    "expires_at_ms": 300000
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 3000, "local_remaining_credits": 2200 }
+                },
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 3000,
+                    "expires_at_ms": 300000
+                },
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 2000,
+                    "expires_at_ms": 300000
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 3000, "local_remaining_credits": 2200 }
+                }
+            ]
+        },
+        {
+            "name": "extend_expiry_only_moves_forward",
+            "description": "An extend carrying an earlier expiry must not shorten the lease: after an extend to a later expiry, a stale out-of-order apply with an earlier expiry leaves the lease live past that earlier instant.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 2000,
+                    "expires_at_ms": 120000
+                },
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 2000,
+                    "expires_at_ms": 30000
+                },
+                { "op": "advance_clock", "ms": 90000 },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 1900 }
+                }
+            ]
+        },
+        {
+            "name": "extend_pinned_to_lease_id_dropped_on_successor",
+            "description": "An extend pinned to a lease the slot no longer holds is dropped entirely — crediting the successor would mint credits the server granted to the expired lease.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_2",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 5000,
+                    "expires_at_ms": 600000,
+                    "pin_lease_id": "lse_1"
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 1000, "local_remaining_credits": 1000 }
+                },
+                {
+                    "op": "extend_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_total": 2000,
+                    "expires_at_ms": 600000,
+                    "pin_lease_id": "lse_2"
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 2000, "local_remaining_credits": 2000 }
+                }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/lease-manager.json
+++ b/conformance/vectors/lease-manager.json
@@ -1,0 +1,417 @@
+{
+    "category": "lease_manager",
+    "vectors": [
+        {
+            "name": "acquire_installs_tranche_and_reuses_live_lease",
+            "description": "First acquire requests lease_size from the server and installs the response at full grant; a second acquire while the lease is live makes no wire call.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": {
+                        "lease": { "lease_id": "lse_1", "granted_amount": 1000, "expires_at_ms": 300000 }
+                    },
+                    "expect": {
+                        "lease_id": "lse_1",
+                        "wire_acquires": 1,
+                        "last_acquire_requested_amount": 1000,
+                        "released_lease_ids": []
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_1", "local_remaining_credits": 1000 }
+                },
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "lease_id": "lse_1", "wire_acquires": 1 }
+                }
+            ]
+        },
+        {
+            "name": "acquire_replaces_expired_slot_without_release",
+            "description": "An expired slot triggers a fresh acquire that supplants the stale entry in place; the redundant-lease release path must not fire (replace wrote, it did not keep a live lease).",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_stale",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": {
+                        "lease": { "lease_id": "lse_fresh", "granted_amount": 1000, "expires_at_ms": 360000 }
+                    },
+                    "expect": { "lease_id": "lse_fresh", "wire_acquires": 1, "released_lease_ids": [] }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_fresh", "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "lost_acquire_race_different_id_releases_redundant_lease",
+            "description": "A sibling installs a live lease while this acquire's wire call is in flight. The installed lease (with its debited balance) wins; the lease the server minted for the loser is redundant and gets released so it is not orphaned against the company balance.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": {
+                        "lease": { "lease_id": "lse_loser", "granted_amount": 1000, "expires_at_ms": 300000 }
+                    },
+                    "install_during_wire": {
+                        "lease_id": "lse_winner",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    },
+                    "expect": { "lease_id": "lse_winner", "wire_acquires": 1, "released_lease_ids": ["lse_loser"] }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "lease_id": "lse_winner" }
+                }
+            ]
+        },
+        {
+            "name": "lost_acquire_race_same_id_releases_nothing",
+            "description": "The server is idempotent for an active slot: a racing acquire is handed back the SAME lease the sibling installed. There is nothing to release — releasing would pull the shared lease out from under every sibling.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": {
+                        "lease": { "lease_id": "lse_shared", "granted_amount": 1000, "expires_at_ms": 300000 }
+                    },
+                    "install_during_wire": {
+                        "lease_id": "lse_shared",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    },
+                    "expect": { "lease_id": "lse_shared", "wire_acquires": 1, "released_lease_ids": [] }
+                }
+            ]
+        },
+        {
+            "name": "extend_triggered_at_low_water_mark_requests_tranche",
+            "description": "At or below the low-water-mark ratio a steady-state extend fires, requesting the configured tranche (lease_size) and reconciling the local row to the server total.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 800,
+                    "expect": { "balance": 200 }
+                },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": { "lease": { "granted_total": 2000, "expires_at_ms": 600000 } },
+                    "expect": {
+                        "wire_extends": 1,
+                        "last_extend_additional_amount": 1000,
+                        "last_extend_lease_id": "lse_1"
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 2000, "local_remaining_credits": 1200 }
+                }
+            ]
+        },
+        {
+            "name": "extend_triggered_by_required_credits_above_watermark",
+            "description": "Above the watermark no steady-state extend fires; a required_credits hint larger than the local remaining triggers one anyway (a check just failed a reserve of that size).",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "wire_extends": 0 }
+                },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "required_credits": 1500,
+                    "server": { "lease": { "granted_total": 2000, "expires_at_ms": 600000 } },
+                    "expect": { "wire_extends": 1, "last_extend_additional_amount": 1000 }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 2000, "local_remaining_credits": 1900 }
+                }
+            ]
+        },
+        {
+            "name": "extend_sized_to_shortfall_when_larger_than_tranche",
+            "description": "additional_amount = max(lease_size, required_credits - local_remaining): a single request larger than remaining + tranche must extend by the shortfall, or its post-extend retry would fail forever regardless of server balance.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "required_credits": 5000,
+                    "server": { "lease": { "granted_total": 5100, "expires_at_ms": 600000 } },
+                    "expect": { "wire_extends": 1, "last_extend_additional_amount": 4100 }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 5100, "local_remaining_credits": 5000 }
+                }
+            ]
+        },
+        {
+            "name": "never_extend_an_expired_lease",
+            "description": "An expired lease is released as far as the server is concerned — the only correct move is a fresh acquire, never an extend, no matter how depleted the balance.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_old",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 900,
+                    "expect": { "balance": 100 }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "required_credits": 1500,
+                    "expect": { "wire_extends": 0 }
+                }
+            ]
+        },
+        {
+            "name": "wire_failures_resolve_to_no_lease_without_state_changes",
+            "description": "A failed acquire yields no lease and installs nothing; a failed extend leaves the local row untouched. Neither throws (both are routed through fail-open/fail-closed by callers).",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                }
+            },
+            "operations": [
+                {
+                    "op": "acquire_if_needed",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": { "error": "wire down" },
+                    "expect": { "lease_id": null, "wire_acquires": 1 }
+                },
+                { "op": "get_lease", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "exists": false } },
+                {
+                    "op": "replace_lease",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "granted_amount": 1000,
+                    "expires_at_ms": 300000,
+                    "expect": { "written": true }
+                },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 800,
+                    "expect": { "balance": 200 }
+                },
+                {
+                    "op": "maybe_extend",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "server": { "error": "wire down" },
+                    "expect": { "wire_extends": 1 }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "granted_amount": 1000, "local_remaining_credits": 200 }
+                }
+            ]
+        },
+        {
+            "name": "release_all_releases_live_and_skips_expired",
+            "description": "On close, a per-process store releases its live leases over the wire (returning remainders immediately) and drops them locally; expired leases are skipped — the server already swept them. Only valid for an exclusively-owned (in-memory) store; a shared backend must never enumerate-and-release.",
+            "backends": ["in_memory"],
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_live",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    },
+                    {
+                        "lease_id": "lse_expired",
+                        "company_id": "co_2",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 30000
+                    }
+                ]
+            },
+            "operations": [
+                { "op": "advance_clock", "ms": 30001 },
+                {
+                    "op": "release_all_local_leases",
+                    "expect": { "released_lease_ids": ["lse_live"] }
+                },
+                { "op": "get_lease", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "exists": false } }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/reservation-lifecycle.json
+++ b/conformance/vectors/reservation-lifecycle.json
@@ -1,0 +1,353 @@
+{
+    "category": "reservation_lifecycle",
+    "vectors": [
+        {
+            "name": "consume_exact_usage_no_refund",
+            "description": "Consuming exactly the reserved amount removes the reservation and refunds nothing.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 100, "expect": { "consumed": 100 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                },
+                { "op": "get_reservation", "id": "res_1", "expect": { "exists": false } }
+            ]
+        },
+        {
+            "name": "consume_under_reserved_refunds_unspent",
+            "description": "Consuming less than reserved refunds the unspent slice to the lease in the same step.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 30, "expect": { "consumed": 30 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 970 }
+                }
+            ]
+        },
+        {
+            "name": "consume_over_reserved_clamps_to_hold",
+            "description": "Local consumption is clamped to credits_reserved: over-use consumes the full hold, refunds nothing, and never debits the lease beyond the reservation. (The billed Track quantity is NOT clamped — see track-settle vectors.)",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 999, "expect": { "consumed": 100 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                }
+            ]
+        },
+        {
+            "name": "consume_zero_cancels_with_full_refund",
+            "description": "Consuming 0 credits acts as a cancel: the full hold is refunded. Negative consumption clamps to 0 the same way.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 0, "expect": { "consumed": 0 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        },
+        {
+            "name": "consume_is_exactly_once",
+            "description": "A missing reservation and a second consume of the same id both return null and refund nothing — the claim is the exactly-once arbiter.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                { "op": "consume_reservation", "id": "res_missing", "credits": 10, "expect": { "consumed": null } },
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 100,
+                    "expect": { "balance": 900 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 30, "expect": { "consumed": 30 } },
+                { "op": "consume_reservation", "id": "res_1", "credits": 30, "expect": { "consumed": null } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 970 }
+                }
+            ]
+        },
+        {
+            "name": "reserved_credits_sums_open_holds_per_slot",
+            "description": "reserved_credits sums credits_reserved across open reservations for the exact (company, credit) slot only, and a hold stops counting the moment it is consumed.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 350,
+                    "expect": { "balance": 650 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 10,
+                    "credits_reserved": 100,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_2",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 25,
+                    "credits_reserved": 250,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_other_credit",
+                    "lease_id": "lse_9",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_2",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 99,
+                    "credits_reserved": 999,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_other_company",
+                    "lease_id": "lse_8",
+                    "company_id": "co_2",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 99,
+                    "credits_reserved": 999,
+                    "consumption_rate": 10,
+                    "expires_at_ms": 60000
+                },
+                {
+                    "op": "reserved_credits",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "total": 350 }
+                },
+                {
+                    "op": "reserved_credits",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_2",
+                    "expect": { "total": 999 }
+                },
+                { "op": "reserved_credits", "company_id": "co_9", "credit_type_id": "ct_1", "expect": { "total": 0 } },
+                { "op": "consume_reservation", "id": "res_1", "credits": 40, "expect": { "consumed": 40 } },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 250 } }
+            ]
+        },
+        {
+            "name": "fractional_credit_amounts_are_exact",
+            "description": "Fractional consumption rates produce fractional holds; reserve, consume, and refund arithmetic must not truncate.",
+            "given": {
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 10,
+                        "expires_at_ms": 60000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "try_reserve",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "credits": 2.5,
+                    "expect": { "balance": 7.5 }
+                },
+                {
+                    "op": "add_reservation",
+                    "id": "res_1",
+                    "lease_id": "lse_1",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "event_subtype": "inference_tokens",
+                    "quantity_reserved": 25,
+                    "credits_reserved": 2.5,
+                    "consumption_rate": 0.1,
+                    "expires_at_ms": 60000
+                },
+                { "op": "consume_reservation", "id": "res_1", "credits": 1.5, "expect": { "consumed": 1.5 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 8.5 }
+                }
+            ]
+        }
+    ]
+}

--- a/conformance/vectors/track-settle.json
+++ b/conformance/vectors/track-settle.json
@@ -1,0 +1,194 @@
+{
+    "category": "track_settle",
+    "vectors": [
+        {
+            "name": "track_underuse_settles_and_refunds_unspent",
+            "description": "Settling with less than the reserved usage consumes actual x rate, refunds the unspent slice to the lease, and emits a Track billing the ACTUAL quantity keyed to the lease.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "save_reservation_as": "r1",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "ok" }
+                    ],
+                    "expect": { "allowed": true, "has_reservation": true }
+                },
+                {
+                    "op": "track",
+                    "handle": "r1",
+                    "actual_quantity": 4,
+                    "expect": {
+                        "settled_locally": true,
+                        "track": { "event": "inference_tokens", "quantity": 4, "lease_id": "lse_1" }
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 960 }
+                },
+                { "op": "reserved_credits", "company_id": "co_1", "credit_type_id": "ct_1", "expect": { "total": 0 } }
+            ]
+        },
+        {
+            "name": "track_overuse_bills_actual_but_clamps_local_debit",
+            "description": "Actual usage above the reservation: the LOCAL settle clamps consumption to the reserved hold (the lease is never debited past the reservation), but the Track event bills the unclamped actual quantity — the server is the source of truth for real consumption.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "save_reservation_as": "r1",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "ok" }
+                    ],
+                    "expect": { "allowed": true, "has_reservation": true }
+                },
+                {
+                    "op": "track",
+                    "handle": "r1",
+                    "actual_quantity": 25,
+                    "expect": {
+                        "settled_locally": true,
+                        "track": { "event": "inference_tokens", "quantity": 25, "lease_id": "lse_1" }
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 900 }
+                }
+            ]
+        },
+        {
+            "name": "track_after_sweep_is_a_recovery_emit",
+            "description": "Work outliving the reservation TTL: the sweeper already refunded the full hold, so the late settle does not touch the lease (the local balance reads high until rollover) — but the Track is still emitted so the server bills the actual usage. Server-side idempotency (a deterministic key derived from the reservation id) is what keeps a racing normal emit from double-billing.",
+            "given": {
+                "config": {
+                    "lease_duration_ms": 300000,
+                    "reservation_ttl_ms": 60000,
+                    "lease_size": 1000,
+                    "low_water_mark": 0.25
+                },
+                "leases": [
+                    {
+                        "lease_id": "lse_1",
+                        "company_id": "co_1",
+                        "credit_type_id": "ct_1",
+                        "granted_amount": 1000,
+                        "expires_at_ms": 300000
+                    }
+                ]
+            },
+            "operations": [
+                {
+                    "op": "check",
+                    "flag_key": "inference",
+                    "company": { "id": "co_1", "credit_balances": { "ct_1": 5000 } },
+                    "usage": 10,
+                    "event_subtype": "inference_tokens",
+                    "save_reservation_as": "r1",
+                    "engine": [
+                        {
+                            "value": true,
+                            "reason": "probe",
+                            "entitlement": {
+                                "value_type": "credit",
+                                "credit_id": "ct_1",
+                                "consumption_rate": 10,
+                                "event_subtype": "inference_tokens"
+                            }
+                        },
+                        { "value": true, "reason": "ok" }
+                    ],
+                    "expect": { "allowed": true, "has_reservation": true }
+                },
+                { "op": "advance_clock", "ms": 60001 },
+                { "op": "sweep_expired", "expect": { "swept": 1 } },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                },
+                {
+                    "op": "track",
+                    "handle": "r1",
+                    "actual_quantity": 4,
+                    "expect": {
+                        "settled_locally": false,
+                        "track": { "event": "inference_tokens", "quantity": 4, "lease_id": "lse_1" }
+                    }
+                },
+                {
+                    "op": "get_lease",
+                    "company_id": "co_1",
+                    "credit_type_id": "ct_1",
+                    "expect": { "exists": true, "local_remaining_credits": 1000 }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/conformance/runner.test.ts
+++ b/tests/conformance/runner.test.ts
@@ -1,0 +1,720 @@
+/**
+ * Executes the language-agnostic conformance vectors in `conformance/vectors/`
+ * against the reference implementation, on both store backends. The vector
+ * schema and the semantics they pin are documented in `conformance/SPEC.md`;
+ * ports of the lease/reservation system reimplement this runner (it is the
+ * only language-specific piece) and must pass the same vectors.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+import type * as api from "../../src/api";
+import type { CreditsClient } from "../../src/api/resources/credits/client/Client";
+import { type CreditCheckDeps, checkWithLease } from "../../src/credits/check";
+import { CreditLeaseManager } from "../../src/credits/lease-manager";
+import { type ILeaseStore, LeaseStore } from "../../src/credits/lease-store";
+import { RedisLeaseStore } from "../../src/credits/redis-lease-store";
+import { RedisReservationStore } from "../../src/credits/redis-reservation-store";
+import { type IReservationStore, ReservationStore } from "../../src/credits/reservation-store";
+import { consumeReservationAndBuildEvent } from "../../src/credits/track";
+import type { CheckOptions, CheckResult, OnAcquireFailure, Reservation } from "../../src/credits/types";
+import type { DataStreamClient } from "../../src/datastream";
+import type { Logger } from "../../src/logger";
+import { makeFakeRedis } from "../unit/credits/fake-redis";
+
+// ---------------------------------------------------------------------------
+// Vector schema (see conformance/SPEC.md — keys are snake_case JSON).
+
+interface LeaseSpec {
+    lease_id: string;
+    company_id: string;
+    credit_type_id: string;
+    granted_amount: number;
+    expires_at_ms: number;
+}
+
+interface ConfigSpec {
+    lease_duration_ms?: number;
+    reservation_ttl_ms?: number;
+    lease_size?: number;
+    low_water_mark?: number;
+}
+
+interface ServerLeaseSpec {
+    lease_id?: string;
+    granted_amount?: number;
+    granted_total?: number;
+    expires_at_ms: number;
+}
+
+type ServerScript = { lease: ServerLeaseSpec; error?: undefined } | { error: string; lease?: undefined };
+
+interface EngineEntitlementSpec {
+    value_type: string;
+    credit_id?: string;
+    consumption_rate?: number;
+    event_subtype?: string;
+}
+
+interface EngineResultSpec {
+    value: boolean;
+    reason?: string;
+    entitlement?: EngineEntitlementSpec;
+}
+
+interface EngineCallExpect {
+    credit_balance?: number | "max_safe_integer";
+    credit_cost?: number;
+    event_usage?: { event_subtype: string; quantity: number };
+    usage?: number;
+}
+
+interface OpExpect {
+    written?: boolean;
+    balance?: number | null;
+    consumed?: number | null;
+    throws?: boolean;
+    exists?: boolean;
+    lease_id?: string | null;
+    granted_amount?: number;
+    local_remaining_credits?: number;
+    total?: number;
+    count?: number;
+    swept?: number;
+    wire_acquires?: number;
+    last_acquire_requested_amount?: number;
+    released_lease_ids?: string[];
+    wire_extends?: number;
+    last_extend_additional_amount?: number;
+    last_extend_lease_id?: string;
+    allowed?: boolean;
+    reason?: string;
+    err?: string;
+    has_reservation?: boolean;
+    reservation?: {
+        lease_id?: string;
+        credit_type_id?: string;
+        event_subtype?: string;
+        quantity_reserved?: number;
+        credits_reserved?: number;
+        consumption_rate?: number;
+    };
+    engine_calls?: EngineCallExpect[];
+    fallback_called?: boolean;
+    settled_locally?: boolean;
+    track?: { event?: string; quantity?: number; lease_id?: string };
+}
+
+interface Operation {
+    op: string;
+    expect?: OpExpect;
+    // advance_clock
+    ms?: number;
+    // lease / reservation store ops
+    lease_id?: string;
+    company_id?: string;
+    credit_type_id?: string;
+    granted_amount?: number;
+    expires_at_ms?: number;
+    credits?: number;
+    pin_lease_id?: string;
+    granted_total?: number;
+    id?: string;
+    handle?: string;
+    event_subtype?: string;
+    quantity_reserved?: number;
+    credits_reserved?: number;
+    consumption_rate?: number;
+    crash_before_refund?: boolean;
+    // manager ops
+    required_credits?: number;
+    server?: ServerScript | { acquire?: ServerScript; extend?: ServerScript };
+    install_during_wire?: LeaseSpec;
+    // check / track ops
+    flag_key?: string;
+    company?: { id: string; credit_balances?: Record<string, number> };
+    usage?: number;
+    on_acquire_failure?: string;
+    engine?: EngineResultSpec[];
+    save_reservation_as?: string;
+    actual_quantity?: number;
+}
+
+interface Vector {
+    name: string;
+    description: string;
+    backends?: string[];
+    given?: { config?: ConfigSpec; leases?: LeaseSpec[] };
+    operations: Operation[];
+}
+
+interface VectorDoc {
+    category: string;
+    vectors: Vector[];
+}
+
+const VECTORS_DIR = path.join(__dirname, "..", "..", "conformance", "vectors");
+const documents: VectorDoc[] = fs
+    .readdirSync(VECTORS_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => JSON.parse(fs.readFileSync(path.join(VECTORS_DIR, f), "utf8")) as VectorDoc);
+
+// ---------------------------------------------------------------------------
+// Backends. The crash hook interposes on the lease store the RESERVATION
+// store refunds through (the consume-then-refund window); every other path
+// uses the raw store. One-shot: it disarms itself when it fires.
+
+interface Stores {
+    leases: ILeaseStore;
+    reservations: IReservationStore;
+    armCrash: () => void;
+}
+
+function crashableRefund(target: ILeaseStore): { store: ILeaseStore; arm: () => void } {
+    let armed = false;
+    return {
+        arm: () => {
+            armed = true;
+        },
+        store: {
+            get: (companyId, creditTypeId) => target.get(companyId, creditTypeId),
+            replace: (entry) => target.replace(entry),
+            extend: (companyId, creditTypeId, grantedAmount, newExpiresAt, leaseId) =>
+                target.extend(companyId, creditTypeId, grantedAmount, newExpiresAt, leaseId),
+            drop: (companyId, creditTypeId) => target.drop(companyId, creditTypeId),
+            tryReserve: (companyId, creditTypeId, credits) => target.tryReserve(companyId, creditTypeId, credits),
+            refund: (companyId, creditTypeId, credits, leaseId) => {
+                if (armed) {
+                    armed = false;
+                    throw new Error("simulated crash before refund");
+                }
+                return target.refund(companyId, creditTypeId, credits, leaseId);
+            },
+        },
+    };
+}
+
+const backends: Array<["in_memory" | "redis", () => Stores]> = [
+    [
+        "in_memory",
+        () => {
+            const leases = new LeaseStore();
+            const crash = crashableRefund(leases);
+            return { leases, reservations: new ReservationStore(crash.store, 60_000), armCrash: crash.arm };
+        },
+    ],
+    [
+        "redis",
+        () => {
+            const client = makeFakeRedis();
+            const leases = new RedisLeaseStore({ client });
+            const crash = crashableRefund(leases);
+            return {
+                leases,
+                reservations: new RedisReservationStore({ client, leaseStore: crash.store, sweepIntervalMs: 60_000 }),
+                armCrash: crash.arm,
+            };
+        },
+    ],
+];
+
+// ---------------------------------------------------------------------------
+// Harness
+
+const T0 = new Date("2026-01-01T00:00:00Z").getTime();
+
+const silentLogger: Logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+// Let floating fire-and-forget promise chains (background extend, redundant
+// release) settle. Only microtasks are involved — no timers.
+async function drain(): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+    }
+}
+
+interface RecordedEngineCall {
+    creditBalances: Record<string, number> | undefined;
+    creditCost: Record<string, number> | undefined;
+    eventUsage: { eventSubtype: string; quantity: number } | undefined;
+    usage: number | undefined;
+}
+
+class Harness {
+    readonly handles = new Map<string, Reservation>();
+    readonly acquireResponses: ServerScript[] = [];
+    readonly extendResponses: ServerScript[] = [];
+    readonly acquireCalls: api.AcquireCreditLeaseRequestBody[] = [];
+    readonly extendCalls: Array<{ leaseId: string; body: api.ExtendCreditLeaseRequestBody }> = [];
+    readonly releaseCalls: string[] = [];
+    installDuringWire: LeaseSpec | undefined;
+    readonly manager: CreditLeaseManager;
+    private elapsed = 0;
+
+    constructor(
+        readonly stores: Stores,
+        config: ConfigSpec,
+    ) {
+        const creditsClient = {
+            acquireCreditLease: async (body: api.AcquireCreditLeaseRequestBody) => {
+                this.acquireCalls.push(body);
+                const install = this.installDuringWire;
+                if (install) {
+                    this.installDuringWire = undefined;
+                    await this.stores.leases.replace({
+                        leaseId: install.lease_id,
+                        companyId: install.company_id,
+                        creditTypeId: install.credit_type_id,
+                        grantedAmount: install.granted_amount,
+                        expiresAt: this.atMs(install.expires_at_ms),
+                    });
+                }
+                const scripted = this.acquireResponses.shift();
+                if (!scripted || scripted.error !== undefined || !scripted.lease) {
+                    throw new Error(scripted?.error ?? "unscripted acquire wire call");
+                }
+                const lease = scripted.lease;
+                return {
+                    data: {
+                        id: lease.lease_id ?? "lse_unnamed",
+                        companyId: body.companyId,
+                        creditTypeId: body.creditTypeId,
+                        grantedAmount: lease.granted_amount ?? 0,
+                        expiresAt: this.atMs(lease.expires_at_ms),
+                        createdAt: this.atMs(0),
+                        updatedAt: this.atMs(0),
+                    },
+                    params: {},
+                };
+            },
+            extendCreditLease: async (leaseId: string, body: api.ExtendCreditLeaseRequestBody) => {
+                this.extendCalls.push({ leaseId, body });
+                const scripted = this.extendResponses.shift();
+                if (!scripted || scripted.error !== undefined || !scripted.lease) {
+                    throw new Error(scripted?.error ?? "unscripted extend wire call");
+                }
+                const lease = scripted.lease;
+                return {
+                    data: {
+                        id: leaseId,
+                        companyId: "co_wire",
+                        creditTypeId: "ct_wire",
+                        grantedAmount: lease.granted_total ?? 0,
+                        expiresAt: this.atMs(lease.expires_at_ms),
+                        createdAt: this.atMs(0),
+                        updatedAt: this.atMs(0),
+                    },
+                    params: {},
+                };
+            },
+            releaseCreditLease: async (leaseId: string) => {
+                this.releaseCalls.push(leaseId);
+                return { data: {}, params: {} };
+            },
+        } as unknown as CreditsClient;
+        this.manager = new CreditLeaseManager({
+            creditsClient,
+            leaseStore: stores.leases,
+            logger: silentLogger,
+            config: {
+                defaultLeaseDuration: config.lease_duration_ms,
+                defaultReservationTTL: config.reservation_ttl_ms,
+                defaultLeaseSize: config.lease_size,
+                lowWaterMark: config.low_water_mark,
+            },
+        });
+    }
+
+    atMs(offset: number): Date {
+        return new Date(T0 + offset);
+    }
+
+    advance(ms: number): void {
+        this.elapsed += ms;
+        jest.setSystemTime(T0 + this.elapsed);
+    }
+
+    setServer(server: Operation["server"]): void {
+        if (!server) return;
+        if ("lease" in server || "error" in server) {
+            // Manager ops script a single call directly.
+            return;
+        }
+        if (server.acquire) this.acquireResponses.push(server.acquire);
+        if (server.extend) this.extendResponses.push(server.extend);
+    }
+
+    resolveReservation(op: Operation): string {
+        if (op.handle !== undefined) {
+            const reservation = this.handles.get(op.handle);
+            if (!reservation) throw new Error(`unknown reservation handle: ${op.handle}`);
+            return reservation.id;
+        }
+        if (op.id === undefined) throw new Error(`op ${op.op} needs an id or handle`);
+        return op.id;
+    }
+}
+
+function mapEntitlement(spec: EngineEntitlementSpec, flagKey: string) {
+    return {
+        featureId: "feat_1",
+        featureKey: flagKey,
+        valueType: spec.value_type,
+        creditId: spec.credit_id,
+        consumptionRate: spec.consumption_rate,
+        eventSubtype: spec.event_subtype,
+    };
+}
+
+async function runCheck(
+    h: Harness,
+    op: Operation,
+): Promise<{ result: CheckResult; engineCalls: RecordedEngineCall[]; fallbackCalled: boolean }> {
+    const flagKey = op.flag_key ?? "flag";
+    const company = op.company ?? { id: "co_1" };
+    const engineResults = [...(op.engine ?? [])];
+    const engineCalls: RecordedEngineCall[] = [];
+    const engine = {
+        checkFlagWithOptions: async (
+            _flag: unknown,
+            evalCompany: { creditBalances?: Record<string, number> },
+            _user: unknown,
+            options: {
+                creditCost?: Record<string, number>;
+                eventUsage?: { eventSubtype: string; quantity: number };
+                usage?: number;
+            } | null,
+        ) => {
+            engineCalls.push({
+                creditBalances: evalCompany.creditBalances,
+                creditCost: options?.creditCost,
+                eventUsage: options?.eventUsage,
+                usage: options?.usage,
+            });
+            const scripted = engineResults.shift();
+            if (!scripted) throw new Error(`unscripted engine call in check op for flag ${flagKey}`);
+            return {
+                value: scripted.value,
+                reason: scripted.reason,
+                flagKey,
+                flagId: "flag_1",
+                entitlement: scripted.entitlement ? mapEntitlement(scripted.entitlement, flagKey) : undefined,
+            };
+        },
+    };
+    const datastream = {
+        getFlag: async () => ({ id: "flag_1", key: flagKey }),
+        getCompany: async () => ({ id: company.id, creditBalances: company.credit_balances ?? {} }),
+        getUser: async () => null,
+        getRulesEngine: () => engine,
+    } as unknown as DataStreamClient;
+
+    h.setServer(op.server);
+
+    let fallbackCalled = false;
+    const fallback = async (): Promise<CheckResult> => {
+        fallbackCalled = true;
+        return { allowed: true, value: true, reason: "fallback", flagKey };
+    };
+
+    const deps: CreditCheckDeps = {
+        leaseStore: h.stores.leases,
+        reservations: h.stores.reservations,
+        manager: h.manager,
+        datastream,
+        logger: silentLogger,
+        enqueueFlagCheckEvent: () => {},
+    };
+    const options: CheckOptions = {
+        usage: op.usage,
+        eventSubtype: op.event_subtype,
+        onAcquireFailure: op.on_acquire_failure as OnAcquireFailure | undefined,
+    };
+    const result = await checkWithLease(deps, flagKey, { company: { id: company.id } }, options, fallback);
+    await drain();
+    return { result, engineCalls, fallbackCalled };
+}
+
+function assertEngineCalls(recorded: RecordedEngineCall[], expected: EngineCallExpect[], creditId: string | undefined) {
+    expect(recorded).toHaveLength(expected.length);
+    expected.forEach((want, i) => {
+        const got = recorded[i];
+        if (want.credit_balance !== undefined) {
+            const wantBalance =
+                want.credit_balance === "max_safe_integer" ? Number.MAX_SAFE_INTEGER : want.credit_balance;
+            expect(creditId).toBeDefined();
+            expect(got.creditBalances?.[creditId as string]).toBe(wantBalance);
+        }
+        if (want.credit_cost !== undefined) {
+            expect(got.creditCost?.[creditId as string]).toBe(want.credit_cost);
+        }
+        if (want.event_usage !== undefined) {
+            expect(got.eventUsage).toEqual({
+                eventSubtype: want.event_usage.event_subtype,
+                quantity: want.event_usage.quantity,
+            });
+        }
+        if (want.usage !== undefined) {
+            expect(got.usage).toBe(want.usage);
+        }
+    });
+}
+
+async function runVector(vector: Vector, makeStores: () => Stores): Promise<void> {
+    const stores = makeStores();
+    const h = new Harness(stores, vector.given?.config ?? {});
+    try {
+        for (const lease of vector.given?.leases ?? []) {
+            expect(
+                await stores.leases.replace({
+                    leaseId: lease.lease_id,
+                    companyId: lease.company_id,
+                    creditTypeId: lease.credit_type_id,
+                    grantedAmount: lease.granted_amount,
+                    expiresAt: h.atMs(lease.expires_at_ms),
+                }),
+            ).toBe(true);
+        }
+
+        for (const op of vector.operations) {
+            const exp = op.expect ?? {};
+            switch (op.op) {
+                case "advance_clock": {
+                    h.advance(op.ms ?? 0);
+                    break;
+                }
+                case "replace_lease": {
+                    const written = await stores.leases.replace({
+                        leaseId: op.lease_id as string,
+                        companyId: op.company_id as string,
+                        creditTypeId: op.credit_type_id as string,
+                        grantedAmount: op.granted_amount as number,
+                        expiresAt: h.atMs(op.expires_at_ms as number),
+                    });
+                    if (exp.written !== undefined) expect(written).toBe(exp.written);
+                    break;
+                }
+                case "drop_lease": {
+                    await stores.leases.drop(op.company_id as string, op.credit_type_id as string);
+                    break;
+                }
+                case "try_reserve": {
+                    const balance = await stores.leases.tryReserve(
+                        op.company_id as string,
+                        op.credit_type_id as string,
+                        op.credits as number,
+                    );
+                    if ("balance" in exp) expect(balance).toBe(exp.balance);
+                    break;
+                }
+                case "refund_lease": {
+                    await stores.leases.refund(
+                        op.company_id as string,
+                        op.credit_type_id as string,
+                        op.credits as number,
+                        op.pin_lease_id,
+                    );
+                    break;
+                }
+                case "extend_lease": {
+                    await stores.leases.extend(
+                        op.company_id as string,
+                        op.credit_type_id as string,
+                        op.granted_total as number,
+                        op.expires_at_ms !== undefined ? h.atMs(op.expires_at_ms) : undefined,
+                        op.pin_lease_id,
+                    );
+                    break;
+                }
+                case "get_lease": {
+                    const entry = await stores.leases.get(op.company_id as string, op.credit_type_id as string);
+                    if (exp.exists !== undefined) expect(entry !== undefined).toBe(exp.exists);
+                    if (exp.lease_id !== undefined) expect(entry?.leaseId).toBe(exp.lease_id);
+                    if (exp.granted_amount !== undefined) expect(entry?.grantedAmount).toBe(exp.granted_amount);
+                    if (exp.local_remaining_credits !== undefined) {
+                        expect(entry?.localRemainingCredits).toBe(exp.local_remaining_credits);
+                    }
+                    break;
+                }
+                case "add_reservation": {
+                    await stores.reservations.add({
+                        id: op.id as string,
+                        leaseId: op.lease_id as string,
+                        companyId: op.company_id as string,
+                        creditTypeId: op.credit_type_id as string,
+                        eventSubtype: op.event_subtype as string,
+                        quantityReserved: op.quantity_reserved as number,
+                        creditsReserved: op.credits_reserved as number,
+                        consumptionRate: op.consumption_rate as number,
+                        expiresAt: h.atMs(op.expires_at_ms as number),
+                        evalCtx: { company: { id: op.company_id as string } },
+                    });
+                    break;
+                }
+                case "consume_reservation": {
+                    const id = h.resolveReservation(op);
+                    if (op.crash_before_refund) {
+                        stores.armCrash();
+                        await expect(stores.reservations.consume(id, op.credits as number)).rejects.toThrow(
+                            "simulated crash before refund",
+                        );
+                        expect(exp.throws).toBe(true);
+                    } else {
+                        const consumed = await stores.reservations.consume(id, op.credits as number);
+                        if ("consumed" in exp) expect(consumed).toBe(exp.consumed);
+                    }
+                    break;
+                }
+                case "get_reservation": {
+                    const reservation = await stores.reservations.get(h.resolveReservation(op));
+                    if (exp.exists !== undefined) expect(reservation !== undefined).toBe(exp.exists);
+                    break;
+                }
+                case "reserved_credits": {
+                    const total = await stores.reservations.reservedCredits(
+                        op.company_id as string,
+                        op.credit_type_id as string,
+                    );
+                    expect(total).toBe(exp.total);
+                    break;
+                }
+                case "reservation_count": {
+                    expect(await stores.reservations.size()).toBe(exp.count);
+                    break;
+                }
+                case "sweep_expired": {
+                    const swept = await stores.reservations.sweepExpired(new Date());
+                    if (exp.swept !== undefined) expect(swept).toBe(exp.swept);
+                    break;
+                }
+                case "acquire_if_needed": {
+                    if (op.server) h.acquireResponses.push(op.server as ServerScript);
+                    if (op.install_during_wire) h.installDuringWire = op.install_during_wire;
+                    const entry = await h.manager.acquireIfNeeded(op.company_id as string, op.credit_type_id as string);
+                    await drain();
+                    if ("lease_id" in exp) expect(entry?.leaseId ?? null).toBe(exp.lease_id);
+                    if (exp.wire_acquires !== undefined) expect(h.acquireCalls).toHaveLength(exp.wire_acquires);
+                    if (exp.last_acquire_requested_amount !== undefined) {
+                        expect(h.acquireCalls[h.acquireCalls.length - 1]?.requestedAmount).toBe(
+                            exp.last_acquire_requested_amount,
+                        );
+                    }
+                    if (exp.released_lease_ids !== undefined) expect(h.releaseCalls).toEqual(exp.released_lease_ids);
+                    break;
+                }
+                case "maybe_extend": {
+                    if (op.server) h.extendResponses.push(op.server as ServerScript);
+                    await h.manager.maybeExtendInBackground(
+                        op.company_id as string,
+                        op.credit_type_id as string,
+                        op.required_credits,
+                    );
+                    await drain();
+                    if (exp.wire_extends !== undefined) expect(h.extendCalls).toHaveLength(exp.wire_extends);
+                    if (exp.last_extend_additional_amount !== undefined) {
+                        expect(h.extendCalls[h.extendCalls.length - 1]?.body.additionalAmount).toBe(
+                            exp.last_extend_additional_amount,
+                        );
+                    }
+                    if (exp.last_extend_lease_id !== undefined) {
+                        expect(h.extendCalls[h.extendCalls.length - 1]?.leaseId).toBe(exp.last_extend_lease_id);
+                    }
+                    break;
+                }
+                case "release_all_local_leases": {
+                    await h.manager.releaseAllLocalLeases();
+                    if (exp.released_lease_ids !== undefined) expect(h.releaseCalls).toEqual(exp.released_lease_ids);
+                    break;
+                }
+                case "check": {
+                    const { result, engineCalls, fallbackCalled } = await runCheck(h, op);
+                    if (exp.allowed !== undefined) expect(result.allowed).toBe(exp.allowed);
+                    if (exp.reason !== undefined) expect(result.reason).toBe(exp.reason);
+                    if (exp.err !== undefined) expect(result.err).toBe(exp.err);
+                    if (exp.has_reservation !== undefined) {
+                        expect(result.reservation !== undefined).toBe(exp.has_reservation);
+                    }
+                    if (exp.fallback_called !== undefined) expect(fallbackCalled).toBe(exp.fallback_called);
+                    if (exp.reservation) {
+                        const r = result.reservation;
+                        expect(r).toBeDefined();
+                        if (exp.reservation.lease_id !== undefined) expect(r?.leaseId).toBe(exp.reservation.lease_id);
+                        if (exp.reservation.credit_type_id !== undefined) {
+                            expect(r?.creditTypeId).toBe(exp.reservation.credit_type_id);
+                        }
+                        if (exp.reservation.event_subtype !== undefined) {
+                            expect(r?.eventSubtype).toBe(exp.reservation.event_subtype);
+                        }
+                        if (exp.reservation.quantity_reserved !== undefined) {
+                            expect(r?.quantityReserved).toBe(exp.reservation.quantity_reserved);
+                        }
+                        if (exp.reservation.credits_reserved !== undefined) {
+                            expect(r?.creditsReserved).toBe(exp.reservation.credits_reserved);
+                        }
+                        if (exp.reservation.consumption_rate !== undefined) {
+                            expect(r?.consumptionRate).toBe(exp.reservation.consumption_rate);
+                        }
+                    }
+                    if (exp.engine_calls !== undefined) {
+                        const creditId =
+                            op.engine?.find((e) => e.entitlement?.credit_id)?.entitlement?.credit_id ??
+                            Object.keys(op.company?.credit_balances ?? {})[0];
+                        assertEngineCalls(engineCalls, exp.engine_calls, creditId);
+                    }
+                    if (exp.wire_extends !== undefined) expect(h.extendCalls).toHaveLength(exp.wire_extends);
+                    if (exp.last_extend_additional_amount !== undefined) {
+                        expect(h.extendCalls[h.extendCalls.length - 1]?.body.additionalAmount).toBe(
+                            exp.last_extend_additional_amount,
+                        );
+                    }
+                    if (op.save_reservation_as && result.reservation) {
+                        h.handles.set(op.save_reservation_as, result.reservation);
+                    }
+                    break;
+                }
+                case "track": {
+                    const reservation = h.handles.get(op.handle as string);
+                    if (!reservation) throw new Error(`unknown reservation handle: ${op.handle}`);
+                    const { track, settledLocally } = await consumeReservationAndBuildEvent(
+                        stores.reservations,
+                        reservation,
+                        op.actual_quantity as number,
+                    );
+                    if (exp.settled_locally !== undefined) expect(settledLocally).toBe(exp.settled_locally);
+                    if (exp.track) {
+                        if (exp.track.event !== undefined) expect(track.event).toBe(exp.track.event);
+                        if (exp.track.quantity !== undefined) expect(track.quantity).toBe(exp.track.quantity);
+                        if (exp.track.lease_id !== undefined) expect(track.leaseId).toBe(exp.track.lease_id);
+                    }
+                    break;
+                }
+                default:
+                    throw new Error(`unknown conformance op: ${op.op}`);
+            }
+        }
+    } finally {
+        stores.reservations.stop();
+    }
+}
+
+describe.each(backends)("credit lease conformance — %s", (backendName, makeStores) => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(T0);
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    for (const doc of documents) {
+        describe(doc.category, () => {
+            for (const vector of doc.vectors) {
+                if (vector.backends && !vector.backends.includes(backendName)) continue;
+                it(vector.name, async () => {
+                    await runVector(vector, makeStores);
+                });
+            }
+        });
+    }
+});


### PR DESCRIPTION
Precursor to SCH-6531 (lease support in other SDKs): extracts the credit lease/reservation semantics from this SDK — the reference implementation — into a language-agnostic conformance suite, so the upcoming Python/Go ports can prove "implements the same semantics" instead of approximating it.

- `conformance/SPEC.md` — the semantics spec (state machine, store-op contracts, check/track flows, config knobs, bounded-leak contract table, and the invariants that can't be vectors), written for implementing from scratch without reading the Node source.
- `conformance/vectors/*.json` — 48 deterministic test vectors (plain JSON, snake_case, virtual clock): reservation lifecycle 7, lease lifecycle 9, expiry 4, crash windows 5, lease manager 10, check flow 10, track/settle 3.
- `tests/conformance/runner.test.ts` — runs every vector against both store backends (in-memory + the existing fake-redis Lua interpreter): 95 passing runs. The runner is the only language-specific piece a port reimplements.

Behaviors worth calling out (vectors follow the code):

- Over-use on settle is asymmetric: the local consume clamps to `credits_reserved`, but the Track event bills the unclamped actual quantity (server is source of truth).
- fail-open is not blanket allow — the engine re-runs with a substituted max balance, so an unentitled company stays denied while the lease backend is down.
- `replace` keeps a live lease even under a different lease id; the losing acquire releases its redundant lease only when the server minted a different id.
- Store `extend` reconciles to the server's absolute total (lower/equal totals are no-ops) and expiry only moves forward; both extend and refund are pinned to the originating lease id and silently dropped if a successor holds the slot.
- Crash windows are direction-locked: the debit/claim is durable first, so crashes leak bounded, lease-expiry-reclaimed credits and can never double-spend or double-refund.

Not capturable as vectors (documented as prose invariants in SPEC.md): single-flight/concurrent-race schedules, Redis server-clock TTL authority and single-key Lua atomicity, NaN guards (JSON can't encode NaN), Track idempotency-key dedupe, the background sweep timer, and offline/unconfigured wrapper degradation.
