### PR TITLE
chore(deps): resolve dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
         "crypto": false,
         "timers": false
     },
+    "resolutions": {
+        "undici": "7.29.0"
+    },
     "packageManager": "yarn@1.22.22",
     "engines": {
         "node": ">=18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,10 +3656,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+undici@7.28.0, undici@7.29.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Resolves the open Dependabot security alerts for `undici` (transitive via `miniflare`) by pinning it to the minimum patched version through a yarn `resolutions` entry.

- GHSA-4cwx-7wf7-3272 — undici — high — 7.28.0 → 7.29.0 — yarn `resolutions` entry (transitive via `miniflare`)
- GHSA-8xcm-r25x-g524 — undici — medium — 7.28.0 → 7.29.0 — yarn `resolutions` entry (transitive via `miniflare`)
- GHSA-jr45-8vmc-qm54 — undici — medium — 7.28.0 → 7.29.0 — yarn `resolutions` entry (transitive via `miniflare`)
- GHSA-m8rv-5g2x-5cg5 — undici — medium — 7.28.0 → 7.29.0 — yarn `resolutions` entry (transitive via `miniflare`)
- GHSA-v3r7-h72x-cjcm — undici — medium — 7.28.0 → 7.29.0 — yarn `resolutions` entry (transitive via `miniflare`)

No major bumps. `yarn why undici` reports a single resolved copy at 7.29.0. `yarn build` and the 5 `wasm-*`/`rules-engine`/`webpack` unit suites fail identically at the base commit (missing gitignored `src/wasm/*` artifacts, not built in this environment); all other suites pass.