### PR TITLE
Cap event capture requests at 100 events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -3,8 +3,12 @@ import { EventCaptureClient } from "./event-capture";
 import { ConsoleLogger, Logger } from "./logger";
 
 const DEFAULT_FLUSH_INTERVAL = 1000; // 1 second
-const DEFAULT_MAX_SIZE = 1000; // 1000 items
+const DEFAULT_MAX_SIZE = 100; // 100 items
 const DEFAULT_MAX_RETRIES = 3;
+// The capture service rejects any batch larger than this with
+// `400 {"error": "batch too large", "max_size": 100}`, so a flush is split
+// into chunks of at most this many events regardless of how many are buffered.
+const MAX_EVENTS_PER_REQUEST = 100;
 const DEFAULT_INITIAL_RETRY_DELAY = 1000; // 1 second in milliseconds
 
 interface EventBufferOptions {
@@ -60,52 +64,71 @@ class EventBuffer {
             const events = [...this.events];
             this.events = [];
 
-            // Initialize retry counter and success flag
-            let retryCount = 0;
-            let success = false;
-            let lastError: any = null;
-
-            // Try with retries and exponential backoff
-            while (retryCount <= this.maxRetries && !success) {
-                try {
-                    if (retryCount > 0) {
-                        // Log retry attempt
-                        this.logger.info(`Retrying event batch submission (attempt ${retryCount} of ${this.maxRetries})`);
-                    }
-
-                    // Attempt to send events
-                    await this.captureClient.sendBatch(events);
-                    success = true;
-                } catch (err) {
-                    lastError = err;
-                    retryCount++;
-
-                    if (retryCount <= this.maxRetries) {
-                        // Calculate backoff with jitter
-                        const delay = this.initialRetryDelay * Math.pow(2, retryCount - 1);
-                        const jitter = Math.random() * 0.1 * delay; // 10% jitter
-                        const waitTime = delay + jitter;
-
-                        this.logger.warn(
-                            `Event batch submission failed: ${err}. Retrying in ${(waitTime / 1000).toFixed(2)} seconds...`
-                        );
-
-                        // Wait before retry
-                        if (process.env.NODE_ENV !== "test") {
-                            await new Promise((resolve) => setTimeout(resolve, waitTime));
-                        }
-                    }
-                }
-            }
-
-            // After all retries, if still not successful, log the error
-            if (!success) {
-                this.logger.error(`Event batch submission failed after ${this.maxRetries} retries:`, lastError);
-            } else if (retryCount > 0) {
-                this.logger.info(`Event batch submission succeeded after ${retryCount} retries`);
+            // The buffer can hold more than one request's worth of events: a
+            // caller that does not await `push` keeps appending while a flush
+            // is in flight, since `push` skips its size check whenever
+            // `flushing` is set. Send in chunks so an oversized buffer is
+            // never turned into an oversized request.
+            //
+            // Each chunk is retried independently. Retrying the whole drained
+            // set together would resend chunks that already succeeded.
+            for (let i = 0; i < events.length; i += MAX_EVENTS_PER_REQUEST) {
+                await this.sendChunk(events.slice(i, i + MAX_EVENTS_PER_REQUEST));
             }
         } finally {
             this.flushing = false;
+        }
+    }
+
+    /**
+     * Sends a single request's worth of events, retrying with exponential
+     * backoff. Failures are logged and the chunk is dropped, matching the
+     * buffer's contract that tracking never throws to the caller.
+     */
+    private async sendChunk(events: CreateEventRequestBody[]): Promise<void> {
+        // Initialize retry counter and success flag
+        let retryCount = 0;
+        let success = false;
+        let lastError: any = null;
+
+        // Try with retries and exponential backoff
+        while (retryCount <= this.maxRetries && !success) {
+            try {
+                if (retryCount > 0) {
+                    // Log retry attempt
+                    this.logger.info(`Retrying event batch submission (attempt ${retryCount} of ${this.maxRetries})`);
+                }
+
+                // Attempt to send events
+                await this.captureClient.sendBatch(events);
+                success = true;
+            } catch (err) {
+                lastError = err;
+                retryCount++;
+
+                if (retryCount <= this.maxRetries) {
+                    // Calculate backoff with jitter
+                    const delay = this.initialRetryDelay * Math.pow(2, retryCount - 1);
+                    const jitter = Math.random() * 0.1 * delay; // 10% jitter
+                    const waitTime = delay + jitter;
+
+                    this.logger.warn(
+                        `Event batch submission failed: ${err}. Retrying in ${(waitTime / 1000).toFixed(2)} seconds...`,
+                    );
+
+                    // Wait before retry
+                    if (process.env.NODE_ENV !== "test") {
+                        await new Promise((resolve) => setTimeout(resolve, waitTime));
+                    }
+                }
+            }
+        }
+
+        // After all retries, if still not successful, log the error
+        if (!success) {
+            this.logger.error(`Event batch submission failed after ${this.maxRetries} retries:`, lastError);
+        } else if (retryCount > 0) {
+            this.logger.info(`Event batch submission succeeded after ${retryCount} retries`);
         }
     }
 

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -97,7 +97,7 @@ describe("EventBuffer", () => {
 
         expect(mockLogger.error).toHaveBeenCalledWith(
             "Event batch submission failed after 1 retries:",
-            expect.any(Error)
+            expect.any(Error),
         );
     });
 
@@ -258,5 +258,114 @@ describe("EventBuffer", () => {
         expect(mockCaptureClient.sendBatch).toHaveBeenCalledTimes(2);
 
         expect(mockLogger.info).toHaveBeenCalledWith("Event batch submission succeeded after 1 retries");
+    });
+
+    describe("batch size cap", () => {
+        const makeEvent = (n: number): CreateEventRequestBody => ({
+            body: {
+                company: { id: "test-company" },
+                event: `test-event-${n}`,
+                user: { id: "test-user" },
+            },
+            eventType: "track",
+            sentAt: new Date(),
+        });
+
+        const batchSizes = () => mockCaptureClient.sendBatch.mock.calls.map((call) => call[0].length);
+
+        it("splits a drained buffer into requests of at most 100 events", async () => {
+            const buffer = new EventBuffer(mockCaptureClient, {
+                logger: mockLogger,
+                // Deliberately larger than the server's cap, to prove the cap
+                // is enforced at send time rather than by the buffer size.
+                maxSize: 1000,
+                interval: 1000,
+            });
+
+            for (let i = 0; i < 250; i++) {
+                await buffer.push(makeEvent(i));
+            }
+            await buffer.flush();
+
+            expect(batchSizes()).toEqual([100, 100, 50]);
+        });
+
+        it("never sends more than 100 events when pushes are not awaited", async () => {
+            // Reproduces the original failure. `push` skips its size check
+            // while a flush is in flight, so a caller that fires `track()`
+            // without awaiting keeps appending for the whole duration of the
+            // in-flight request. Hold the first request open so the buffer
+            // grows well past the cap before it is drained again.
+            let releaseFirstSend: () => void = () => undefined;
+            const firstSendHeld = new Promise<void>((resolve) => {
+                releaseFirstSend = resolve;
+            });
+            mockCaptureClient.sendBatch.mockImplementationOnce(() => firstSendHeld);
+
+            const buffer = new EventBuffer(mockCaptureClient, {
+                logger: mockLogger,
+                maxSize: 100,
+                interval: 1000,
+            });
+
+            const pushes = Promise.all(Array.from({ length: 300 }, (_, i) => buffer.push(makeEvent(i))));
+            // Let every push run up to the point where it appends or blocks.
+            await Promise.resolve();
+            releaseFirstSend();
+            await pushes;
+            await buffer.stop();
+
+            expect(mockCaptureClient.sendBatch).toHaveBeenCalled();
+            for (const size of batchSizes()) {
+                expect(size).toBeLessThanOrEqual(100);
+            }
+            const total = batchSizes().reduce((sum, size) => sum + size, 0);
+            expect(total).toBe(300);
+        });
+
+        it("does not resend a delivered chunk when a later chunk fails", async () => {
+            mockCaptureClient.sendBatch
+                .mockResolvedValueOnce(undefined) // chunk 1 delivered
+                .mockRejectedValue(new Error("boom")); // chunk 2 fails every attempt
+
+            const buffer = new EventBuffer(mockCaptureClient, {
+                logger: mockLogger,
+                maxSize: 1000,
+                interval: 1000,
+                maxRetries: 2,
+                initialRetryDelay: 1,
+            });
+
+            for (let i = 0; i < 150; i++) {
+                await buffer.push(makeEvent(i));
+            }
+            await buffer.flush();
+
+            // 1 delivery for chunk 1, then 1 + 2 retries for chunk 2.
+            expect(mockCaptureClient.sendBatch).toHaveBeenCalledTimes(4);
+
+            const firstChunk = mockCaptureClient.sendBatch.mock.calls[0][0];
+            const resends = mockCaptureClient.sendBatch.mock.calls.filter((call) => call[0] === firstChunk);
+            expect(resends).toHaveLength(1);
+        });
+
+        it("still attempts later chunks after an earlier chunk fails", async () => {
+            mockCaptureClient.sendBatch.mockRejectedValueOnce(new Error("boom")).mockResolvedValue(undefined);
+
+            const buffer = new EventBuffer(mockCaptureClient, {
+                logger: mockLogger,
+                maxSize: 1000,
+                interval: 1000,
+                maxRetries: 0,
+                initialRetryDelay: 1,
+            });
+
+            for (let i = 0; i < 150; i++) {
+                await buffer.push(makeEvent(i));
+            }
+            await buffer.flush();
+
+            expect(batchSizes()).toEqual([100, 50]);
+        });
     });
 });


### PR DESCRIPTION
## Problem

The capture service rejects any batch over 100 events with `400 {"error": "batch too large", "max_size": 100}` ([`capture.go:73`](https://github.com/schematichq/schematic-api/blob/main/api/apps/events/web/capture.go)), but `EventBuffer.flush()` drained its entire backlog into a single `sendBatch` call. Any caller with more than 100 buffered events lost the whole batch, with only a log line to show for it.

Found by a daily cron in `schematic-dashai` that tracked 113 companies and then called `close()`. All 113 events went out as one request and 400'd, losing a full day of usage data.

## Why `maxSize` did not already prevent this

`maxSize` gates the push-triggered flush, and only when a flush is not already running:

```ts
if (this.events.length >= this.maxSize && !this.flushing) {
    await this.flush();
}
this.events.push(event);
```

So it is a soft ceiling. The buffer grows past it whenever:

1. **A flush is in flight.** `flushing` short-circuits the size check, and callers keep appending for the full duration of the request, retry backoff included.
2. **The caller does not await `track()`.** Pushes interleave across the `await this.flush()` yield point inside `push`.

The new test `never sends more than 100 events when pushes are not awaited` reproduces case 1 and produces a **200-event request** against the old code.

## Changes

- **Chunk each flush into requests of at most 100 events**, retrying each chunk independently. Per-chunk retries matter here: retrying the whole drained set would resend chunks that had already been delivered. The retry loop is unchanged, just extracted into `sendChunk`.
- **Lower the default `maxSize` from 1000 to 100** so the common path is one request per flush and the chunking is a safety net rather than the primary path.

Failure behavior is unchanged: a chunk that exhausts `maxRetries` is logged and dropped, and does not prevent later chunks from being attempted.

## When this became reachable

The 1000 default predates the move to the capture service. Through 1.4.x the buffer flushed via the REST `createEventBatch` endpoint; **1.5.0 switched it to `EventCaptureClient.sendBatch` against `c.schematichq.com/batch`**, which enforces the cap. The mismatch was latent before that. Anything on a caret range picked this up as a routine dependency bump, which is exactly how it reached the demo.

## Cross-SDK status

I checked every SDK with an event buffer. `schematic-go`, `schematic-java`, and `schematic-csharp` already hard-cap the drain at 100 and are correct. `schematic-python` and `schematic-ruby` have the same unbounded-drain shape as this and get their own PRs. `schematic-js` sends events one at a time and is unaffected.

## Testing

Four new tests in `tests/unit/events.test.ts`, all four confirmed failing without the source change:

- splits a drained buffer into requests of at most 100 events
- never sends more than 100 events when pushes are not awaited (the regression case, sends 200 without the fix)
- does not resend a delivered chunk when a later chunk fails
- still attempts later chunks after an earlier chunk fails

Full unit suite is unchanged against baseline: 83 failed / 820 passed before, 83 failed / 824 passed after. The pre-existing failures are the WASM and webpack suites, which need a build step, and are identical on a clean checkout.

## Follow-ups not in this PR

- `stop()` awaits `flush()`, but `flush()` returns immediately when `flushing` is already set, so a `close()` landing during an in-flight flush silently drops everything buffered after it.
- The retry loop treats a deterministic 4xx as transient and burns `maxRetries` with backoff on a request that can never succeed.
- `maxSize` is not exposed on `SchematicOptions` (only `eventBufferInterval` is), so there was no config-level workaround available to the affected caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)